### PR TITLE
Support nonglobal custom csv readwriters

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -111,6 +111,9 @@ func UnmarshalBytes(in []byte, out interface{}) (err error) {
 
 // Unmarshal parses the CSV from the reader in the interface.
 func Unmarshal(in io.Reader, out interface{}) (err error) {
-	return newDecoder(in).readTo(out)
+	return readTo(newDecoder(in), out)
 }
 
+func UnmarshalCSV(in *csv.Reader, out interface{}) error {
+	return readTo(csvDecoder{in}, out)
+}

--- a/csv.go
+++ b/csv.go
@@ -88,7 +88,12 @@ func MarshalBytes(in interface{}) (out []byte, err error) {
 
 // Marshal returns the CSV in writer from the interface.
 func Marshal(in interface{}, out io.Writer) (err error) {
-	return newEncoder(out).writeTo(in)
+	writer := getCSVWriter(out)
+	return writeTo(writer, in)
+}
+
+func MarshalCSV(in interface{}, out *csv.Writer) (err error) {
+	return writeTo(out, in)
 }
 
 // --------------------------------------------------------------------------

--- a/decode.go
+++ b/decode.go
@@ -14,6 +14,10 @@ func newDecoder(in io.Reader) *decoder {
 	return &decoder{in}
 }
 
+func (decode *decoder) getCSVRows() ([][]string, error) {
+	return getCSVReader(decode.in).ReadAll()
+}
+
 func (decode *decoder) readTo(out interface{}) error {
 	outValue, outType := getConcreteReflectValueAndType(out) // Get the concrete type (not pointer) (Slice<?> or Array<?>)
 	if err := ensureOutType(outType); err != nil {
@@ -112,8 +116,4 @@ func setInnerField(outInner *reflect.Value, outInnerWasPointer bool, index []int
 		oi = outInner.Elem()
 	}
 	return setField(oi.FieldByIndex(index), value)
-}
-
-func (decode *decoder) getCSVRows() ([][]string, error) {
-	return getCSVReader(decode.in).ReadAll()
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -10,7 +10,7 @@ e,3,b`)
 	d := &decoder{in: b}
 
 	var samples []Sample
-	if err := d.readTo(&samples); err != nil {
+	if err := readTo(d, &samples); err != nil {
 		t.Fatal(err)
 	}
 	if len(samples) != 2 {
@@ -33,7 +33,7 @@ ff,gg,22,hh,ii,jj`)
 	d := &decoder{in: b}
 
 	var samples []SkipFieldSample
-	if err := d.readTo(&samples); err != nil {
+	if err := readTo(d, &samples); err != nil {
 		t.Fatal(err)
 	}
 	if len(samples) != 2 {

--- a/encode.go
+++ b/encode.go
@@ -16,11 +16,11 @@ func newEncoder(out io.Writer) *encoder {
 
 func (encode *encoder) writeTo(in interface{}) error {
 	inValue, inType := getConcreteReflectValueAndType(in) // Get the concrete type (not pointer) (Slice<?> or Array<?>)
-	if err := encode.ensureInType(inType); err != nil {
+	if err := ensureInType(inType); err != nil {
 		return err
 	}
 	inInnerWasPointer, inInnerType := getConcreteContainerInnerType(inType) // Get the concrete inner type (not pointer) (Container<"?">)
-	if err := encode.ensureInInnerType(inInnerType); err != nil {
+	if err := ensureInInnerType(inInnerType); err != nil {
 		return err
 	}
 	csvWriter := getCSVWriter(encode.out)           // Get the CSV writer
@@ -34,7 +34,7 @@ func (encode *encoder) writeTo(in interface{}) error {
 	for i := 0; i < inLen; i++ { // Iterate over container rows
 		for j, fieldInfo := range inInnerStructInfo.Fields {
 			csvHeadersLabels[j] = ""
-			inInnerFieldValue, err := encode.getInnerField(inValue.Index(i), inInnerWasPointer, fieldInfo.IndexChain) // Get the correct field header <-> position
+			inInnerFieldValue, err := getInnerField(inValue.Index(i), inInnerWasPointer, fieldInfo.IndexChain) // Get the correct field header <-> position
 			if err != nil {
 				return err
 			}
@@ -47,7 +47,7 @@ func (encode *encoder) writeTo(in interface{}) error {
 }
 
 // Check if the inType is an array or a slice
-func (encode *encoder) ensureInType(outType reflect.Type) error {
+func ensureInType(outType reflect.Type) error {
 	switch outType.Kind() {
 	case reflect.Slice:
 		fallthrough
@@ -58,7 +58,7 @@ func (encode *encoder) ensureInType(outType reflect.Type) error {
 }
 
 // Check if the inInnerType is of type struct
-func (encode *encoder) ensureInInnerType(outInnerType reflect.Type) error {
+func ensureInInnerType(outInnerType reflect.Type) error {
 	switch outInnerType.Kind() {
 	case reflect.Struct:
 		return nil
@@ -66,7 +66,7 @@ func (encode *encoder) ensureInInnerType(outInnerType reflect.Type) error {
 	return fmt.Errorf("cannot use " + outInnerType.String() + ", only struct supported")
 }
 
-func (encode *encoder) getInnerField(outInner reflect.Value, outInnerWasPointer bool, index []int) (string, error) {
+func getInnerField(outInner reflect.Value, outInnerWasPointer bool, index []int) (string, error) {
 	oi := outInner
 	if outInnerWasPointer {
 		oi = outInner.Elem()

--- a/encode.go
+++ b/encode.go
@@ -1,6 +1,7 @@
 package gocsv
 
 import (
+	"encoding/csv"
 	"fmt"
 	"io"
 	"reflect"
@@ -14,7 +15,7 @@ func newEncoder(out io.Writer) *encoder {
 	return &encoder{out}
 }
 
-func (encode *encoder) writeTo(in interface{}) error {
+func writeTo(writer *csv.Writer, in interface{}) error {
 	inValue, inType := getConcreteReflectValueAndType(in) // Get the concrete type (not pointer) (Slice<?> or Array<?>)
 	if err := ensureInType(inType); err != nil {
 		return err
@@ -23,13 +24,14 @@ func (encode *encoder) writeTo(in interface{}) error {
 	if err := ensureInInnerType(inInnerType); err != nil {
 		return err
 	}
-	csvWriter := getCSVWriter(encode.out)           // Get the CSV writer
 	inInnerStructInfo := getStructInfo(inInnerType) // Get the inner struct info to get CSV annotations
 	csvHeadersLabels := make([]string, len(inInnerStructInfo.Fields))
 	for i, fieldInfo := range inInnerStructInfo.Fields { // Used to write the header (first line) in CSV
 		csvHeadersLabels[i] = fieldInfo.Key
 	}
-	csvWriter.Write(csvHeadersLabels)
+	if err := writer.Write(csvHeadersLabels); err != nil {
+		return err
+	}
 	inLen := inValue.Len()
 	for i := 0; i < inLen; i++ { // Iterate over container rows
 		for j, fieldInfo := range inInnerStructInfo.Fields {
@@ -40,10 +42,12 @@ func (encode *encoder) writeTo(in interface{}) error {
 			}
 			csvHeadersLabels[j] = inInnerFieldValue
 		}
-		csvWriter.Write(csvHeadersLabels)
+		if err := writer.Write(csvHeadersLabels); err != nil {
+			return err
+		}
 	}
-	csvWriter.Flush()
-	return nil
+	writer.Flush()
+	return writer.Error()
 }
 
 // Check if the inType is an array or a slice

--- a/encode_test.go
+++ b/encode_test.go
@@ -25,7 +25,7 @@ func Test_writeTo(t *testing.T) {
 		{Foo: "f", Bar: 1, Baz: "baz"},
 		{Foo: "e", Bar: 3, Baz: "b"},
 	}
-	if err := e.writeTo(s); err != nil {
+	if err := writeTo(csv.NewWriter(e.out), s); err != nil {
 		t.Fatal(err)
 	}
 
@@ -52,7 +52,7 @@ func Test_writeTo_embed(t *testing.T) {
 			Quux:   "zzz",
 		},
 	}
-	if err := e.writeTo(s); err != nil {
+	if err := writeTo(csv.NewWriter(e.out), s); err != nil {
 		t.Fatal(err)
 	}
 
@@ -86,7 +86,7 @@ func Test_writeTo_complex_embed(t *testing.T) {
 			Corge:      "hhh",
 		},
 	}
-	if err := e.writeTo(sfs); err != nil {
+	if err := writeTo(csv.NewWriter(e.out), sfs); err != nil {
 		t.Fatal(err)
 	}
 	lines, err := csv.NewReader(&b).ReadAll()


### PR DESCRIPTION
This pull-request would allow greater control to developers to configure a csv.Writer/csv.Reader, as appropriate (e.g. create a pipe-delimited csv.Reader), without the need to modify global package state.