### PR TITLE
Fail if unmatched structtags

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 )
 
+var FailIfUnmatchedStructTags = false
+
 // --------------------------------------------------------------------------
 // CSVWriter used to format CSV
 

--- a/decode.go
+++ b/decode.go
@@ -2,6 +2,7 @@ package gocsv
 
 import (
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -47,7 +48,11 @@ func readTo(decoder Decoder, out interface{}) error {
 	if err := ensureOutCapacity(&outValue, len(csvRows)); err != nil { // Ensure the container is big enough to hold the CSV content
 		return err
 	}
-	outInnerStructInfo := getStructInfo(outInnerType)                            // Get the inner struct info to get CSV annotations
+	outInnerStructInfo := getStructInfo(outInnerType) // Get the inner struct info to get CSV annotations
+	if len(outInnerStructInfo.Fields) == 0 {
+		return errors.New("no csv struct tags found")
+	}
+
 	csvHeadersLabels := make(map[int]*fieldInfo, len(outInnerStructInfo.Fields)) // Used to store the correspondance header <-> position in CSV
 	for i, csvRow := range csvRows {                                             // Iterate over csv rows
 		if i == 0 { // First line of CSV is the header line

--- a/decode.go
+++ b/decode.go
@@ -32,6 +32,24 @@ func (c csvDecoder) getCSVRows() ([][]string, error) {
 	return c.Reader.ReadAll()
 }
 
+func maybeMissingStructFields(structInfo []fieldInfo, headers []string) error {
+	if len(structInfo) == 0 {
+		return nil
+	}
+
+	headerMap := make(map[string]struct{}, len(headers))
+	for idx := range headers {
+		headerMap[headers[idx]] = struct{}{}
+	}
+
+	for _, info := range structInfo {
+		if _, ok := headerMap[info.Key]; !ok {
+			return fmt.Errorf("found unmatched struct tag %v", info.Key)
+		}
+	}
+	return nil
+}
+
 func readTo(decoder Decoder, out interface{}) error {
 	outValue, outType := getConcreteReflectValueAndType(out) // Get the concrete type (not pointer) (Slice<?> or Array<?>)
 	if err := ensureOutType(outType); err != nil {
@@ -52,26 +70,32 @@ func readTo(decoder Decoder, out interface{}) error {
 	if len(outInnerStructInfo.Fields) == 0 {
 		return errors.New("no csv struct tags found")
 	}
+	headers := csvRows[0]
+	body := csvRows[1:]
 
 	csvHeadersLabels := make(map[int]*fieldInfo, len(outInnerStructInfo.Fields)) // Used to store the correspondance header <-> position in CSV
-	for i, csvRow := range csvRows {                                             // Iterate over csv rows
-		if i == 0 { // First line of CSV is the header line
-			for j, csvColumnHeader := range csvRow {
-				if fieldInfo := getCSVFieldPosition(csvColumnHeader, outInnerStructInfo); fieldInfo != nil {
-					csvHeadersLabels[j] = fieldInfo
-				}
-			}
-		} else {
-			outInner := createNewOutInner(outInnerWasPointer, outInnerType)
-			for j, csvColumnContent := range csvRow {
-				if fieldInfo, ok := csvHeadersLabels[j]; ok { // Position found accordingly to header name
-					if err := setInnerField(&outInner, outInnerWasPointer, fieldInfo.IndexChain, csvColumnContent); err != nil { // Set field of struct
-						return err
-					}
-				}
-			}
-			outValue.Index(i - 1).Set(outInner)
+
+	for i, csvColumnHeader := range headers {
+		if fieldInfo := getCSVFieldPosition(csvColumnHeader, outInnerStructInfo); fieldInfo != nil {
+			csvHeadersLabels[i] = fieldInfo
 		}
+	}
+	if err := maybeMissingStructFields(outInnerStructInfo.Fields, headers); err != nil {
+		if FailIfUnmatchedStructTags {
+			return err
+		}
+	}
+
+	for i, csvRow := range body {
+		outInner := createNewOutInner(outInnerWasPointer, outInnerType)
+		for j, csvColumnContent := range csvRow {
+			if fieldInfo, ok := csvHeadersLabels[j]; ok { // Position found accordingly to header name
+				if err := setInnerField(&outInner, outInnerWasPointer, fieldInfo.IndexChain, csvColumnContent); err != nil { // Set field of struct
+					return err
+				}
+			}
+		}
+		outValue.Index(i).Set(outInner)
 	}
 	return nil
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -70,3 +70,41 @@ ff,gg,22,hh,ii,jj`)
 		t.Fatalf("expected first sample %v, got %v", expected, samples[1])
 	}
 }
+
+func Test_maybeMissingStructFields(t *testing.T) {
+	structTags := []fieldInfo{
+		{Key: "foo"},
+		{Key: "bar"},
+		{Key: "baz"},
+	}
+	badHeaders := []string{"hi", "mom", "bacon"}
+	goodHeaders := []string{"foo", "bar", "baz"}
+
+	// no tags to match, expect no error
+	if err := maybeMissingStructFields([]fieldInfo{}, goodHeaders); err != nil {
+		t.Fatal(err)
+	}
+
+	// bad headers, expect an error
+	if err := maybeMissingStructFields(structTags, badHeaders); err == nil {
+		t.Fatal("expected an error, but no error found")
+	}
+
+	// good headers, expect no error
+	if err := maybeMissingStructFields(structTags, goodHeaders); err != nil {
+		t.Fatal(err)
+	}
+
+	// extra headers, but all structtags match; expect no error
+	moarHeaders := append(goodHeaders, "qux", "quux", "corge", "grault")
+	if err := maybeMissingStructFields(structTags, moarHeaders); err != nil {
+		t.Fatal(err)
+	}
+
+	// not all structTags match, but there's plenty o' headers; expect
+	// error
+	mismatchedHeaders := []string{"foo", "qux", "quux", "corgi"}
+	if err := maybeMissingStructFields(structTags, mismatchedHeaders); err == nil {
+		t.Fatal("expected an error, but no error found")
+	}
+}


### PR DESCRIPTION
This is a follow-up patch to https://github.com/gocarina/gocsv/pull/9, where a number of refactorings occurred to facilitate the work contained here.

The aim of this patch-set is to be more rigorous during csv parsing, where gocsv can fail early if expected columns, defined by annotations within the struct that gocsv is populating, don't all exist.  That is, given a csv of the form:
```
column1,column2,column3
1,2,3
4,5,6
...
```
and a corresponding struct defined as 
```go
type SomeStruct struct {
    Field1 int `csv:"column1"`
    Field3 int `csv:"column3"`
    Field4 int `csv:"column4"`
}
```
gocsv can now error while parsing.  In contrast, previous behavior would just populate `SomeStruct.Field4` with the default zero value, and silently continue until the field is used, which usually is detrimental.

This behavior can be toggled via the `FailIfUnmatchedStructTags` flag, and by default, it's set to false (i.e. existing behavior).