### PR TITLE
Fix float formatting

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -3,6 +3,7 @@ package gocsv
 import (
 	"bytes"
 	"encoding/csv"
+	"math"
 	"testing"
 )
 
@@ -22,8 +23,8 @@ func Test_writeTo(t *testing.T) {
 	b := bytes.Buffer{}
 	e := &encoder{out: &b}
 	s := []Sample{
-		{Foo: "f", Bar: 1, Baz: "baz"},
-		{Foo: "e", Bar: 3, Baz: "b"},
+		{Foo: "f", Bar: 1, Baz: "baz", Frop: 0.1},
+		{Foo: "e", Bar: 3, Baz: "b", Frop: 6.0 / 13},
 	}
 	if err := writeTo(csv.NewWriter(e.out), s); err != nil {
 		t.Fatal(err)
@@ -36,9 +37,9 @@ func Test_writeTo(t *testing.T) {
 	if len(lines) != 3 {
 		t.Fatalf("expected 3 lines, got %d", len(lines))
 	}
-	assertLine(t, []string{"foo", "BAR", "Baz"}, lines[0])
-	assertLine(t, []string{"f", "1", "baz"}, lines[1])
-	assertLine(t, []string{"e", "3", "b"}, lines[2])
+	assertLine(t, []string{"foo", "BAR", "Baz", "Quux"}, lines[0])
+	assertLine(t, []string{"f", "1", "baz", "0.1"}, lines[1])
+	assertLine(t, []string{"e", "3", "b", "0.46153846"}, lines[2])
 }
 
 func Test_writeTo_embed(t *testing.T) {
@@ -47,9 +48,10 @@ func Test_writeTo_embed(t *testing.T) {
 	s := []EmbedSample{
 		{
 			Qux:    "aaa",
-			Sample: Sample{Foo: "f", Bar: 1, Baz: "baz"},
+			Sample: Sample{Foo: "f", Bar: 1, Baz: "baz", Frop: 0.2},
 			Ignore: "shouldn't be marshalled",
 			Quux:   "zzz",
+			Grault: math.Pi,
 		},
 	}
 	if err := writeTo(csv.NewWriter(e.out), s); err != nil {
@@ -63,8 +65,8 @@ func Test_writeTo_embed(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(lines))
 	}
-	assertLine(t, []string{"first", "foo", "BAR", "Baz", "last"}, lines[0])
-	assertLine(t, []string{"aaa", "f", "1", "baz", "zzz"}, lines[1])
+	assertLine(t, []string{"first", "foo", "BAR", "Baz", "Quux", "garply", "last"}, lines[0])
+	assertLine(t, []string{"aaa", "f", "1", "baz", "0.2", "3.141592653589793", "zzz"}, lines[1])
 }
 
 func Test_writeTo_complex_embed(t *testing.T) {
@@ -75,11 +77,13 @@ func Test_writeTo_complex_embed(t *testing.T) {
 			EmbedSample: EmbedSample{
 				Qux: "aaa",
 				Sample: Sample{
-					Foo: "bbb",
-					Bar: 111,
-					Baz: "ddd",
+					Foo:  "bbb",
+					Bar:  111,
+					Baz:  "ddd",
+					Frop: 1.2e22,
 				},
 				Ignore: "eee",
+				Grault: 0.1,
 				Quux:   "fff",
 			},
 			MoreIgnore: "ggg",
@@ -96,6 +100,6 @@ func Test_writeTo_complex_embed(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(lines))
 	}
-	assertLine(t, []string{"first", "foo", "BAR", "Baz", "last", "abc"}, lines[0])
-	assertLine(t, []string{"aaa", "bbb", "111", "ddd", "fff", "hhh"}, lines[1])
+	assertLine(t, []string{"first", "foo", "BAR", "Baz", "Quux", "garply", "last", "abc"}, lines[0])
+	assertLine(t, []string{"aaa", "bbb", "111", "ddd", "12000000000000000000000", "0.1", "fff", "hhh"}, lines[1])
 }

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -1,16 +1,18 @@
 package gocsv
 
 type Sample struct {
-	Foo string `csv:"foo"`
-	Bar int    `csv:"BAR"`
-	Baz string `csv:"Baz"`
+	Foo  string  `csv:"foo"`
+	Bar  int     `csv:"BAR"`
+	Baz  string  `csv:"Baz"`
+	Frop float32 `csv:"Quux"`
 }
 
 type EmbedSample struct {
 	Qux string `csv:"first"`
 	Sample
-	Ignore string `csv:"-"`
-	Quux   string `csv:"last"`
+	Ignore string  `csv:"-"`
+	Grault float64 `csv:"garply"`
+	Quux   string  `csv:"last"`
 }
 
 type SkipFieldSample struct {

--- a/types.go
+++ b/types.go
@@ -237,7 +237,12 @@ func getFieldAsString(field reflect.Value) (str string, err error) {
 		if err != nil {
 			return str, err
 		}
-	case reflect.Float32, reflect.Float64:
+	case reflect.Float32:
+		str, err = toString(float32(field.Float()))
+		if err != nil {
+			return str, err
+		}
+	case reflect.Float64:
 		str, err = toString(field.Float())
 		if err != nil {
 			return str, err

--- a/types.go
+++ b/types.go
@@ -57,8 +57,10 @@ func toString(in interface{}) (string, error) {
 		return fmt.Sprintf("%v", inValue.Int()), nil
 	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return fmt.Sprintf("%v", inValue.Uint()), nil
-	case reflect.Float32, reflect.Float64:
-		return strconv.FormatFloat(inValue.Float(), byte('f'), 64, 64), nil
+	case reflect.Float32:
+		return strconv.FormatFloat(inValue.Float(), byte('f'), -1, 32), nil
+	case reflect.Float64:
+		return strconv.FormatFloat(inValue.Float(), byte('f'), -1, 64), nil
 	}
 	return "", fmt.Errorf("No known conversion from " + inValue.Type().String() + " to string")
 }


### PR DESCRIPTION
The old code was emitting floats with 64 decimal digits of precision,
which is probably not what was intended.  Instead pass '-1' to let strconv
decide, and pass through the real precision of the value so that it makes
the right choice for the precision of value being marshaled out.