### PR TITLE
Wrap type conversion errors that occur while parsing in csv.ParseErrors

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -94,7 +94,11 @@ func readTo(decoder Decoder, out interface{}) error {
 		for j, csvColumnContent := range csvRow {
 			if fieldInfo, ok := csvHeadersLabels[j]; ok { // Position found accordingly to header name
 				if err := setInnerField(&outInner, outInnerWasPointer, fieldInfo.IndexChain, csvColumnContent); err != nil { // Set field of struct
-					return err
+					return &csv.ParseError{
+						Line:   i + 2, //add 2 to account for the header & 0-indexing of arrays
+						Column: j + 1,
+						Err:    err,
+					}
 				}
 			}
 		}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,7 +1,10 @@
 package gocsv
 
-import "bytes"
-import "testing"
+import (
+	"bytes"
+	"encoding/csv"
+	"testing"
+)
 
 func Test_readTo(t *testing.T) {
 	b := bytes.NewBufferString(`foo,BAR,Baz
@@ -24,6 +27,28 @@ e,3,b`)
 	if expected != samples[1] {
 		t.Fatalf("expected second sample %v, got %v", expected, samples[1])
 	}
+
+	b = bytes.NewBufferString(`foo,BAR,Baz
+f,1,baz
+e,BAD_INPUT,b`)
+	d = csvDecoder{csv.NewReader(b)}
+	samples = []Sample{}
+	err := readTo(d, &samples)
+	if err == nil {
+		t.Fatalf("Expected error from bad input, got: %+v", samples)
+	}
+	switch actualErr := err.(type) {
+	case *csv.ParseError:
+		if actualErr.Line != 3 {
+			t.Fatalf("Expected csv.ParseError on line 3, got: %d", actualErr.Line)
+		}
+		if actualErr.Column != 2 {
+			t.Fatalf("Expected csv.ParseError in column 2, got: %d", actualErr.Column)
+		}
+	default:
+		t.Fatalf("incorrect error type: %T", err)
+	}
+
 }
 
 func Test_readTo_complex_embed(t *testing.T) {


### PR DESCRIPTION
This provides richer information to the consumer, allowing them to know where in the cvs the error occurred.