### PR TITLE
Fixed line count error in readEach

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -19,7 +19,7 @@ type SimpleDecoder interface {
 }
 
 type decoder struct {
-	in io.Reader
+	in         io.Reader
 	csvDecoder *csvDecoder
 }
 
@@ -175,6 +175,7 @@ func readEach(decoder SimpleDecoder, c interface{}) error {
 			}
 		}
 		outValue.Send(outInner)
+		i++
 	}
 	outValue.Close()
 	return nil


### PR DESCRIPTION
As `i` was never incremented errors were always reported on line 2.