### PR TITLE
Optional fail on double header names

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -9,16 +9,20 @@ package gocsv
 import (
 	"bytes"
 	"encoding/csv"
+	"fmt"
 	"io"
 	"os"
-	"strings"
 	"reflect"
-	"fmt"
+	"strings"
 )
 
 // FailIfUnmatchedStructTags indicates whether it is considered an error when there is an unmatched
 // struct tag.
 var FailIfUnmatchedStructTags = false
+
+// FailIfDoubleHeaderNames indicates whether it is considered an error when a header name is repeated
+// in the csv header.
+var FailIfDoubleHeaderNames = false
 
 // --------------------------------------------------------------------------
 // CSVWriter used to format CSV
@@ -99,7 +103,7 @@ func Marshal(in interface{}, out io.Writer) (err error) {
 }
 
 // MarshalChan returns the CSV read from the channel.
-func MarshalChan(c <- chan interface{}, out *csv.Writer) error {
+func MarshalChan(c <-chan interface{}, out *csv.Writer) error {
 	return writeFromChan(out, c)
 }
 

--- a/decode.go
+++ b/decode.go
@@ -91,6 +91,7 @@ func readTo(decoder Decoder, out interface{}) error {
 	if len(outInnerStructInfo.Fields) == 0 {
 		return errors.New("no csv struct tags found")
 	}
+
 	headers := csvRows[0]
 	body := csvRows[1:]
 
@@ -104,6 +105,16 @@ func readTo(decoder Decoder, out interface{}) error {
 	if err := maybeMissingStructFields(outInnerStructInfo.Fields, headers); err != nil {
 		if FailIfUnmatchedStructTags {
 			return err
+		}
+	}
+	// Check that no header name is repeated twice
+	// TODO: Put into own method, add config variable and add test
+	headerMap := make(map[string]bool, len(headers))
+	for _, v := range headers {
+		if _, ok := headerMap[v]; ok {
+			return fmt.Errorf("Repeated header name: %v", v)
+		} else {
+			headerMap[v] = true
 		}
 	}
 
@@ -154,6 +165,7 @@ func readEach(decoder SimpleDecoder, c interface{}) error {
 			return err
 		}
 	}
+	// TODO: Add check for double header names here as well as for readTo (and somewhere else?)
 	i := 0
 	for {
 		line, err := decoder.getCSVRow()


### PR DESCRIPTION
On parsing a CSV I have no control over I got confused by a repeated column header name. Imho ,similar to fail on unused struct tags, this could be optionally considered as a failure. In this branch I created a variable to enable fail on double header names and raise an error in these cases. 

Test code is also created. Please review and check if you think this is of use.