### PR TITLE
Support renamed types

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -3,6 +3,9 @@ package gocsv
 import (
 	"bytes"
 	"encoding/csv"
+	"io"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -293,4 +296,40 @@ ff,gg,22,hh,ii,jj`)
 	if expected != samples[1] {
 		t.Fatalf("expected first sample %v, got %v", expected, samples[1])
 	}
+}
+
+// TestRenamedTypes tests for unmarshaling/marshaling functions on redefined basic types.
+func TestRenamedTypes(t *testing.T) {
+	b := bytes.NewBufferString(`foo;bar
+1,4;1.5
+2,3;2.4`)
+	d := &decoder{in: b}
+	var samples []RenamedSample
+
+	// Set different csv field separator to enable comma in floats
+	SetCSVReader(func(in io.Reader) *csv.Reader {
+		csvin := csv.NewReader(in)
+		csvin.Comma = ';'
+		return csvin
+	})
+
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+	if samples[0].RenamedFloatUnmarshaler != 1.4 {
+		t.Fatalf("Parsed float value wrong for renamed float64 type. Expected 1.4, got %v.", samples[0].RenamedFloatUnmarshaler)
+	}
+	if samples[0].RenamedFloatDefault != 1.5 {
+		t.Fatalf("Parsed float value wrong for renamed float64 type without an explicit unmarshaler function. Expected 1.5, got %v.", samples[0].RenamedFloatDefault)
+	}
+}
+
+func (rf *RenamedFloat64Unmarshaler) UnmarshalCSV(csv string) (err error) {
+	converted := strings.Replace(csv, ",", ".", -1)
+	var f float64
+	if f, err = strconv.ParseFloat(converted, 64); err != nil {
+		return err
+	}
+	*rf = RenamedFloat64Unmarshaler(f)
+	return nil
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -298,8 +298,8 @@ ff,gg,22,hh,ii,jj`)
 	}
 }
 
-// TestRenamedTypes tests for unmarshaling/marshaling functions on redefined basic types.
-func TestRenamedTypes(t *testing.T) {
+// TestRenamedTypes tests for unmarshaling functions on redefined basic types.
+func TestRenamedTypesUnmarshal(t *testing.T) {
 	b := bytes.NewBufferString(`foo;bar
 1,4;1.5
 2,3;2.4`)

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -21,3 +21,12 @@ type SkipFieldSample struct {
 	MoreIgnore string `csv:"-"`
 	Corge      string `csv:"abc"`
 }
+
+// Testtype for unmarshal/marshal functions on renamed basic types
+type RenamedFloat64Unmarshaler float64
+type RenamedFloat64Default float64
+
+type RenamedSample struct {
+	RenamedFloatUnmarshaler RenamedFloat64Unmarshaler `csv:"foo"`
+	RenamedFloatDefault     RenamedFloat64Default     `csv:"bar"`
+}

--- a/types.go
+++ b/types.go
@@ -188,32 +188,33 @@ func toFloat(in interface{}) (float64, error) {
 }
 
 func setField(field reflect.Value, value string) error {
-	switch field.Kind() {
-	case reflect.String:
+	// TODO: Same method for type switching in other functions
+	switch field.Interface().(type) {
+	case string:
 		s, err := toString(value)
 		if err != nil {
 			return err
 		}
 		field.SetString(s)
-	case reflect.Bool:
+	case bool:
 		b, err := toBool(value)
 		if err != nil {
 			return err
 		}
 		field.SetBool(b)
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+	case int, int8, int16, int32, int64:
 		i, err := toInt(value)
 		if err != nil {
 			return err
 		}
 		field.SetInt(i)
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case uint, uint8, uint16, uint32, uint64:
 		ui, err := toUint(value)
 		if err != nil {
 			return err
 		}
 		field.SetUint(ui)
-	case reflect.Float32, reflect.Float64:
+	case float32, float64:
 		f, err := toFloat(value)
 		if err != nil {
 			return err

--- a/types.go
+++ b/types.go
@@ -221,7 +221,46 @@ func setField(field reflect.Value, value string) error {
 		}
 		field.SetFloat(f)
 	default:
-		return unmarshall(field, value)
+		// Not a native type, check for unmarshal method
+		if err := unmarshall(field, value); err != nil {
+			// Could not unmarshal, check for kind, e.g. renamed type from basic type
+			switch field.Kind() {
+			case reflect.String:
+				s, err := toString(value)
+				if err != nil {
+					return err
+				}
+				field.SetString(s)
+			case reflect.Bool:
+				b, err := toBool(value)
+				if err != nil {
+					return err
+				}
+				field.SetBool(b)
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				i, err := toInt(value)
+				if err != nil {
+					return err
+				}
+				field.SetInt(i)
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				ui, err := toUint(value)
+				if err != nil {
+					return err
+				}
+				field.SetUint(ui)
+			case reflect.Float32, reflect.Float64:
+				f, err := toFloat(value)
+				if err != nil {
+					return err
+				}
+				field.SetFloat(f)
+			default:
+				return err
+			}
+		} else {
+			return nil
+		}
 	}
 	return nil
 }

--- a/types.go
+++ b/types.go
@@ -188,7 +188,6 @@ func toFloat(in interface{}) (float64, error) {
 }
 
 func setField(field reflect.Value, value string) error {
-	// TODO: Same method for type switching in other functions
 	switch field.Interface().(type) {
 	case string:
 		s, err := toString(value)
@@ -273,35 +272,74 @@ func getFieldAsString(field reflect.Value) (str string, err error) {
 			return "", nil
 		}
 		return getFieldAsString(field.Elem())
-	case reflect.String:
-		return field.String(), nil
-	case reflect.Bool:
-		str, err = toString(field.Bool())
-		if err != nil {
-			return str, err
-		}
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		str, err = toString(field.Int())
-		if err != nil {
-			return str, err
-		}
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		str, err = toString(field.Uint())
-		if err != nil {
-			return str, err
-		}
-	case reflect.Float32:
-		str, err = toString(float32(field.Float()))
-		if err != nil {
-			return str, err
-		}
-	case reflect.Float64:
-		str, err = toString(field.Float())
-		if err != nil {
-			return str, err
-		}
 	default:
-		return marshall(field)
+		// Check if field is go native type
+		switch field.Interface().(type) {
+		case string:
+			return field.String(), nil
+		case bool:
+			str, err = toString(field.Bool())
+			if err != nil {
+				return str, err
+			}
+		case int, int8, int16, int32, int64:
+			str, err = toString(field.Int())
+			if err != nil {
+				return str, err
+			}
+		case uint, uint8, uint16, uint32, uint64:
+			str, err = toString(field.Uint())
+			if err != nil {
+				return str, err
+			}
+		case float32:
+			str, err = toString(float32(field.Float()))
+			if err != nil {
+				return str, err
+			}
+		case float64:
+			str, err = toString(field.Float())
+			if err != nil {
+				return str, err
+			}
+		default:
+			// Not a native type, check for marshal method
+			str, err = marshall(field)
+			if err != nil {
+				// If not marshal method, is field compatible with/renamed from native type
+				switch field.Kind() {
+				case reflect.String:
+					return field.String(), nil
+				case reflect.Bool:
+					str, err = toString(field.Bool())
+					if err != nil {
+						return str, err
+					}
+				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+					str, err = toString(field.Int())
+					if err != nil {
+						return str, err
+					}
+				case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+					str, err = toString(field.Uint())
+					if err != nil {
+						return str, err
+					}
+				case reflect.Float32:
+					str, err = toString(float32(field.Float()))
+					if err != nil {
+						return str, err
+					}
+				case reflect.Float64:
+					str, err = toString(field.Float())
+					if err != nil {
+						return str, err
+					}
+				}
+			} else {
+				return str, nil
+			}
+		}
 	}
 	return str, nil
 }


### PR DESCRIPTION
When creating a non-struct type renamed from a base type, e.g. type MyFloat float64, custom defined Unmarshal/Marshal functions on this type are not executed. This branch keeps the default behaviour, aka uses the standard conversion methods if no unmarshal function is defined, but executes the function if they are defined on the type. 

Example use case: When the decimal point is not a . but a , a custom parser function is necessary. See test cases for a working example and please review for problems I might have missed.