### PR TITLE
Bug fix: Switch back to default csv reader/writer after test func

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -312,6 +312,8 @@ func TestRenamedTypesUnmarshal(t *testing.T) {
 		csvin.Comma = ';'
 		return csvin
 	})
+	// Switch back to default for tests executed after this
+	defer SetCSVReader(DefaultCSVReader)
 
 	if err := readTo(d, &samples); err != nil {
 		t.Fatal(err)

--- a/encode_test.go
+++ b/encode_test.go
@@ -151,6 +151,9 @@ func TestRenamedTypesMarshal(t *testing.T) {
 		csvout.Comma = ';'
 		return csvout
 	})
+	// Switch back to default for tests executed after this
+	defer SetCSVWriter(DefaultCSVWriter)
+
 	csvContent, err := MarshalString(&samples)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Found a bug in the test function for (un-)marshal methods on renamed basic types. For test purposes I switch to a csv reader/writer with ; as a separator, but you will need to switch back to the default for following test functions. Found this while preparing a new feature branch/pull request. 

P.S: Sorry for bothering, there are two more pull requests to come and then everything I need for csv parsing should be covered.