### PR TITLE
Multilabels

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -371,7 +371,7 @@ e,3,b`)
 		t.Fatal(err)
 	}
 	if samples[0].Foo != "b" {
-		t.Fatal("expected second tag value in multi tag struct field.")
+		t.Fatalf("expected second tag value 'b' in multi tag struct field, got %v", samples[0].Foo)
 	}
 
 	b = bytes.NewBufferString(`foo,BAR
@@ -382,7 +382,7 @@ e,3`)
 		t.Fatal(err)
 	}
 	if samples[0].Foo != "e" {
-		t.Fatal("wrong value in multi tag struct field")
+		t.Fatalf("wrong value in multi tag struct field, expected 'e', got %v", samples[0].Foo)
 	}
 
 	b = bytes.NewBufferString(`BAR,Baz

--- a/decode_test.go
+++ b/decode_test.go
@@ -373,4 +373,26 @@ e,3,b`)
 	if samples[0].Foo != "b" {
 		t.Fatal("expected second tag value in multi tag struct field.")
 	}
+
+	b = bytes.NewBufferString(`foo,BAR
+e,3`)
+	d = &decoder{in: b}
+
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+	if samples[0].Foo != "e" {
+		t.Fatal("wrong value in multi tag struct field")
+	}
+
+	b = bytes.NewBufferString(`BAR,Baz
+3,b`)
+	d = &decoder{in: b}
+
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+	if samples[0].Foo != "b" {
+		t.Fatal("wrong value in multi tag struct field")
+	}
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -312,6 +312,8 @@ func TestRenamedTypesUnmarshal(t *testing.T) {
 		csvin.Comma = ';'
 		return csvin
 	})
+	// Switch back to default for tests executed after this
+	defer SetCSVReader(DefaultCSVReader)
 
 	if err := readTo(d, &samples); err != nil {
 		t.Fatal(err)

--- a/decode_test.go
+++ b/decode_test.go
@@ -360,3 +360,17 @@ type UnmarshalError struct {
 func (e UnmarshalError) Error() string {
 	return e.msg
 }
+
+func TestMultipleStructTags(t *testing.T) {
+	b := bytes.NewBufferString(`foo,BAR,Baz
+e,3,b`)
+	d := &decoder{in: b}
+
+	var samples []MultiTagSample
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+	if samples[0].Foo != "b" {
+		t.Fatal("expected second tag value in multi tag struct field.")
+	}
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -151,6 +151,9 @@ func TestRenamedTypesMarshal(t *testing.T) {
 		csvout.Comma = ';'
 		return csvout
 	})
+	// Switch back to default for tests executed after this
+	defer SetCSVWriter(DefaultCSVWriter)
+
 	csvContent, err := MarshalString(&samples)
 	if err != nil {
 		t.Fatal(err)

--- a/reflect.go
+++ b/reflect.go
@@ -50,20 +50,21 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 			fieldsList = append(fieldsList, getFieldInfos(field.Type, indexChain)...)
 			continue
 		}
-		fieldInfo := fieldInfo{IndexChain: indexChain}
 		fieldTag := field.Tag.Get("csv")
 		fieldTags := strings.Split(fieldTag, ",")
 		for _, fieldTagEntry := range fieldTags {
 			if fieldTagEntry != "omitempty" {
 				fieldTag = fieldTagEntry
+				fieldInfo := fieldInfo{IndexChain: indexChain}
+
+				if fieldTag == "-" {
+					continue
+				} else {
+					fieldInfo.Key = fieldTag
+				}
+				fieldsList = append(fieldsList, fieldInfo)
 			}
 		}
-		if fieldTag == "-" {
-			continue
-		} else {
-			fieldInfo.Key = fieldTag
-		}
-		fieldsList = append(fieldsList, fieldInfo)
 	}
 	return fieldsList
 }

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -30,3 +30,8 @@ type RenamedSample struct {
 	RenamedFloatUnmarshaler RenamedFloat64Unmarshaler `csv:"foo"`
 	RenamedFloatDefault     RenamedFloat64Default     `csv:"bar"`
 }
+
+type MultiTagSample struct {
+	Foo string `csv:"Baz,foo"`
+	Bar int    `csv:"BAR"`
+}


### PR DESCRIPTION
Enable mapping of multiple header labels on a single struct field. As there already was the functionality to specify different tags on a struct field separated by , these can now be used to both be mapped on the same field.

What is this good for? I have the case where I need to parse csv files with the exact same layout, but german and english headers. Mapping two tags on the same field lets me reuse the struct.