### PR TITLE
Tagseparator

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -24,6 +24,9 @@ var FailIfUnmatchedStructTags = false
 // in the csv header.
 var FailIfDoubleHeaderNames = false
 
+// TagSeparator defines seperator string for multiple csv tags in struct fields
+var TagSeparator = ","
+
 // --------------------------------------------------------------------------
 // CSVWriter used to format CSV
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -396,3 +396,20 @@ e,3`)
 		t.Fatal("wrong value in multi tag struct field")
 	}
 }
+
+func TestStructTagSeparator(t *testing.T) {
+	b := bytes.NewBufferString(`foo,BAR,Baz
+e,3,b`)
+	d := &decoder{in: b}
+
+	TagSeparator = "|"
+
+	var samples []TagSeparatorSample
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+
+	if samples[0].Foo != "b" {
+		t.Fatal("expected second tag value in multi tag struct field.")
+	}
+}

--- a/reflect.go
+++ b/reflect.go
@@ -51,7 +51,7 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 			continue
 		}
 		fieldTag := field.Tag.Get("csv")
-		fieldTags := strings.Split(fieldTag, ",")
+		fieldTags := strings.Split(fieldTag, TagSeparator)
 		for _, fieldTagEntry := range fieldTags {
 			if fieldTagEntry != "omitempty" {
 				fieldTag = fieldTagEntry

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -35,3 +35,8 @@ type MultiTagSample struct {
 	Foo string `csv:"Baz,foo"`
 	Bar int    `csv:"BAR"`
 }
+
+type TagSeparatorSample struct {
+	Foo string `csv:"Baz|foo"`
+	Bar int    `csv:"BAR"`
+}


### PR DESCRIPTION
Specifying an alternative field separator should also enable the possibility to specify a separator for the struct tags. 

Example: Replacing the default csv reader with a custom one which uses ; as the field separator leads to fully valid header fields containing ,
But this mapping cannot be defined as the current implementation expects , to separate multiple csv struct tags. 

Please be aware that this pull request is based on the previous multilabel pull request.