### PR TITLE
Use the first tag when marshalling to CSV

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -61,8 +61,15 @@ func maybeMissingStructFields(structInfo []fieldInfo, headers []string) error {
 	}
 
 	for _, info := range structInfo {
-		if _, ok := headerMap[info.Key]; !ok {
-			return fmt.Errorf("found unmatched struct tag %v", info.Key)
+		found := false
+		for _, key := range info.keys {
+			if _, ok := headerMap[key]; ok {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("found unmatched struct field with tags %v", info.keys)
 		}
 	}
 	return nil
@@ -244,7 +251,7 @@ func ensureOutCapacity(out *reflect.Value, csvLen int) error {
 
 func getCSVFieldPosition(key string, structInfo *structInfo) *fieldInfo {
 	for _, field := range structInfo.Fields {
-		if field.Key == key {
+		if field.matchesKey(key) {
 			return &field
 		}
 	}

--- a/decode.go
+++ b/decode.go
@@ -114,8 +114,9 @@ func readTo(decoder Decoder, out interface{}) error {
 			csvHeadersLabels[i] = fieldInfo
 		}
 	}
-	if err := maybeMissingStructFields(outInnerStructInfo.Fields, headers); err != nil {
-		if FailIfUnmatchedStructTags {
+
+	if FailIfUnmatchedStructTags {
+		if err := maybeMissingStructFields(outInnerStructInfo.Fields, headers); err != nil {
 			return err
 		}
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -152,9 +152,9 @@ ff,gg,22,hh,ii,jj`)
 
 func Test_maybeMissingStructFields(t *testing.T) {
 	structTags := []fieldInfo{
-		{Key: "foo"},
-		{Key: "bar"},
-		{Key: "baz"},
+		{keys: []string{"foo"}},
+		{keys: []string{"bar"}},
+		{keys: []string{"baz"}},
 	}
 	badHeaders := []string{"hi", "mom", "bacon"}
 	goodHeaders := []string{"foo", "bar", "baz"}

--- a/decode_test.go
+++ b/decode_test.go
@@ -400,7 +400,9 @@ func TestStructTagSeparator(t *testing.T) {
 e,3,b`)
 	d := &decoder{in: b}
 
+	defaultTagSeparator := TagSeparator
 	TagSeparator = "|"
+	defer func() { TagSeparator = defaultTagSeparator }()
 
 	var samples []TagSeparatorSample
 	if err := readTo(d, &samples); err != nil {

--- a/encode.go
+++ b/encode.go
@@ -26,7 +26,7 @@ func writeFromChan(writer *csv.Writer, c <-chan interface{}) error {
 	inInnerStructInfo := getStructInfo(inType) // Get the inner struct info to get CSV annotations
 	csvHeadersLabels := make([]string, len(inInnerStructInfo.Fields))
 	for i, fieldInfo := range inInnerStructInfo.Fields { // Used to write the header (first line) in CSV
-		csvHeadersLabels[i] = fieldInfo.Key
+		csvHeadersLabels[i] = fieldInfo.getFirstKey()
 	}
 	if err := writer.Write(csvHeadersLabels); err != nil {
 		return err
@@ -73,7 +73,7 @@ func writeTo(writer *csv.Writer, in interface{}) error {
 	inInnerStructInfo := getStructInfo(inInnerType) // Get the inner struct info to get CSV annotations
 	csvHeadersLabels := make([]string, len(inInnerStructInfo.Fields))
 	for i, fieldInfo := range inInnerStructInfo.Fields { // Used to write the header (first line) in CSV
-		csvHeadersLabels[i] = fieldInfo.Key
+		csvHeadersLabels[i] = fieldInfo.getFirstKey()
 	}
 	if err := writer.Write(csvHeadersLabels); err != nil {
 		return err

--- a/encode_test.go
+++ b/encode_test.go
@@ -45,6 +45,30 @@ func Test_writeTo(t *testing.T) {
 	assertLine(t, []string{"e", "3", "b", "0.46153846153846156", ""}, lines[2])
 }
 
+func Test_writeTo_multipleTags(t *testing.T) {
+	b := bytes.Buffer{}
+	e := &encoder{out: &b}
+	s := []MultiTagSample{
+		{Foo: "abc", Bar: 123},
+		{Foo: "def", Bar: 234},
+	}
+	if err := writeTo(csv.NewWriter(e.out), s); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, err := csv.NewReader(&b).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+	// the first tag for each field is the encoding CSV header
+	assertLine(t, []string{"Baz", "BAR"}, lines[0])
+	assertLine(t, []string{"abc", "123"}, lines[1])
+	assertLine(t, []string{"def", "234"}, lines[2])
+}
+
 func Test_writeTo_embed(t *testing.T) {
 	b := bytes.Buffer{}
 	e := &encoder{out: &b}


### PR DESCRIPTION
Multiple struct tags is very useful when unmarshalling from CSV, for example to map a single struct field from multiple possible source columns. It seems less useful to duplicate the same struct field data to multiple CSV columns.

This change chooses the first struct tag when marshalling to CSV. This makes it possible to add additional struct tags for unmarshalling without changing the CSV structure for marshalling.