### PR TITLE
Add support for unmarshalling into pointer fields

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -4,15 +4,19 @@ import (
 	"bytes"
 	"encoding/csv"
 	"io"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 )
 
 func Test_readTo(t *testing.T) {
-	b := bytes.NewBufferString(`foo,BAR,Baz
-f,1,baz
-e,3,b`)
+	blah := 0
+	sptr := "*string"
+	sptr2 := ""
+	b := bytes.NewBufferString(`foo,BAR,Baz,Blah,SPtr
+f,1,baz,,*string
+e,3,b,,`)
 	d := &decoder{in: b}
 
 	var samples []Sample
@@ -22,12 +26,14 @@ e,3,b`)
 	if len(samples) != 2 {
 		t.Fatalf("expected 2 sample instances, got %d", len(samples))
 	}
-	expected := Sample{Foo: "f", Bar: 1, Baz: "baz"}
-	if expected != samples[0] {
+
+	expected := Sample{Foo: "f", Bar: 1, Baz: "baz", Blah: &blah, SPtr: &sptr}
+	if !reflect.DeepEqual(expected, samples[0]) {
 		t.Fatalf("expected first sample %v, got %v", expected, samples[0])
 	}
-	expected = Sample{Foo: "e", Bar: 3, Baz: "b"}
-	if expected != samples[1] {
+
+	expected = Sample{Foo: "e", Bar: 3, Baz: "b", Blah: &blah, SPtr: &sptr2}
+	if !reflect.DeepEqual(expected, samples[1]) {
 		t.Fatalf("expected second sample %v, got %v", expected, samples[1])
 	}
 

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -6,6 +6,7 @@ type Sample struct {
 	Baz  string  `csv:"Baz"`
 	Frop float64 `csv:"Quux"`
 	Blah *int    `csv:"Blah"`
+	SPtr *string `csv:"SPtr"`
 }
 
 type EmbedSample struct {

--- a/types.go
+++ b/types.go
@@ -206,6 +206,13 @@ func toFloat(in interface{}) (float64, error) {
 }
 
 func setField(field reflect.Value, value string) error {
+	if field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		field = field.Elem()
+	}
+
 	switch field.Interface().(type) {
 	case string:
 		s, err := toString(value)


### PR DESCRIPTION
If a pointer field is included in the CSV file, it will receive a Go zero-value.
If a pointer field is absent from the CSV file, it will retain a nil value.

Fixes #41