### PR TITLE
add MarshalWithoutHeaders

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -102,7 +102,13 @@ func MarshalBytes(in interface{}) (out []byte, err error) {
 // Marshal returns the CSV in writer from the interface.
 func Marshal(in interface{}, out io.Writer) (err error) {
 	writer := getCSVWriter(out)
-	return writeTo(writer, in)
+	return writeTo(writer, in, false)
+}
+
+// Marshal returns the CSV in writer from the interface.
+func MarshalWithoutHeaders(in interface{}, out io.Writer) (err error) {
+	writer := getCSVWriter(out)
+	return writeTo(writer, in, true)
 }
 
 // MarshalChan returns the CSV read from the channel.
@@ -112,7 +118,7 @@ func MarshalChan(c <-chan interface{}, out *csv.Writer) error {
 
 // MarshalCSV returns the CSV in writer from the interface.
 func MarshalCSV(in interface{}, out *csv.Writer) (err error) {
-	return writeTo(out, in)
+	return writeTo(out, in, false)
 }
 
 // --------------------------------------------------------------------------

--- a/encode.go
+++ b/encode.go
@@ -61,7 +61,7 @@ func writeFromChan(writer *csv.Writer, c <-chan interface{}) error {
 	return writer.Error()
 }
 
-func writeTo(writer *csv.Writer, in interface{}) error {
+func writeTo(writer *csv.Writer, in interface{}, omitHeaders bool) error {
 	inValue, inType := getConcreteReflectValueAndType(in) // Get the concrete type (not pointer) (Slice<?> or Array<?>)
 	if err := ensureInType(inType); err != nil {
 		return err
@@ -75,8 +75,10 @@ func writeTo(writer *csv.Writer, in interface{}) error {
 	for i, fieldInfo := range inInnerStructInfo.Fields { // Used to write the header (first line) in CSV
 		csvHeadersLabels[i] = fieldInfo.getFirstKey()
 	}
-	if err := writer.Write(csvHeadersLabels); err != nil {
-		return err
+	if !omitHeaders {
+		if err := writer.Write(csvHeadersLabels); err != nil {
+			return err
+		}
 	}
 	inLen := inValue.Len()
 	for i := 0; i < inLen; i++ { // Iterate over container rows

--- a/encode_test.go
+++ b/encode_test.go
@@ -30,7 +30,7 @@ func Test_writeTo(t *testing.T) {
 		{Foo: "f", Bar: 1, Baz: "baz", Frop: 0.1, Blah: &blah, SPtr: &sptr},
 		{Foo: "e", Bar: 3, Baz: "b", Frop: 6.0 / 13, Blah: nil, SPtr: nil},
 	}
-	if err := writeTo(csv.NewWriter(e.out), s); err != nil {
+	if err := writeTo(csv.NewWriter(e.out), s, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -46,6 +46,30 @@ func Test_writeTo(t *testing.T) {
 	assertLine(t, []string{"e", "3", "b", "0.46153846153846156", "", ""}, lines[2])
 }
 
+func Test_writeTo_NoHeaders(t *testing.T) {
+	b := bytes.Buffer{}
+	e := &encoder{out: &b}
+	blah := 2
+	sptr := "*string"
+	s := []Sample{
+		{Foo: "f", Bar: 1, Baz: "baz", Frop: 0.1, Blah: &blah, SPtr: &sptr},
+		{Foo: "e", Bar: 3, Baz: "b", Frop: 6.0 / 13, Blah: nil, SPtr: nil},
+	}
+	if err := writeTo(csv.NewWriter(e.out), s, true); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, err := csv.NewReader(&b).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	assertLine(t, []string{"f", "1", "baz", "0.1", "2", "*string"}, lines[0])
+	assertLine(t, []string{"e", "3", "b", "0.46153846153846156", "", ""}, lines[1])
+}
+
 func Test_writeTo_multipleTags(t *testing.T) {
 	b := bytes.Buffer{}
 	e := &encoder{out: &b}
@@ -53,7 +77,7 @@ func Test_writeTo_multipleTags(t *testing.T) {
 		{Foo: "abc", Bar: 123},
 		{Foo: "def", Bar: 234},
 	}
-	if err := writeTo(csv.NewWriter(e.out), s); err != nil {
+	if err := writeTo(csv.NewWriter(e.out), s, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -84,7 +108,7 @@ func Test_writeTo_embed(t *testing.T) {
 			Grault: math.Pi,
 		},
 	}
-	if err := writeTo(csv.NewWriter(e.out), s); err != nil {
+	if err := writeTo(csv.NewWriter(e.out), s, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -123,7 +147,7 @@ func Test_writeTo_complex_embed(t *testing.T) {
 			Corge:      "hhh",
 		},
 	}
-	if err := writeTo(csv.NewWriter(e.out), sfs); err != nil {
+	if err := writeTo(csv.NewWriter(e.out), sfs, false); err != nil {
 		t.Fatal(err)
 	}
 	lines, err := csv.NewReader(&b).ReadAll()


### PR DESCRIPTION
Allows the consumer to specify to leave out the header line in the csv that is generated as brought up in issue #3