### PR TITLE
accept CSVReader interface

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -145,7 +145,7 @@ func Unmarshal(in io.Reader, out interface{}) (err error) {
 }
 
 // UnmarshalCSV parses the CSV from the reader in the interface.
-func UnmarshalCSV(in *csv.Reader, out interface{}) error {
+func UnmarshalCSV(in CSVReader, out interface{}) error {
 	return readTo(csvDecoder{in}, out)
 }
 

--- a/decode.go
+++ b/decode.go
@@ -38,8 +38,13 @@ func (decode *decoder) getCSVRow() ([]string, error) {
 	return decode.csvDecoder.Read()
 }
 
+type CSVReader interface {
+	Read() ([]string, error)
+	ReadAll() ([][]string, error)
+}
+
 type csvDecoder struct {
-	*csv.Reader
+	CSVReader
 }
 
 func (c csvDecoder) getCSVRows() ([][]string, error) {


### PR DESCRIPTION
This allows consumers to implement and use their own csv readers. Could be useful in the case that one wants to handle irregular rows in a special way.