### PR TITLE
Support aligning duplicate CSV row headers with the matching duplicate

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -24,7 +24,10 @@ var FailIfUnmatchedStructTags = false
 // in the csv header.
 var FailIfDoubleHeaderNames = false
 
-// TagSeparator defines separator string for multiple csv tags in struct fields
+// Indicates whether we should align duplicate CSV headers per their alignment in the struct definition
+var ShouldAlignDuplicateHeadersWithStructFieldOrder = false
+
+// TagSeparator defines seperator string for multiple csv tags in struct fields
 var TagSeparator = ","
 
 // --------------------------------------------------------------------------

--- a/csv.go
+++ b/csv.go
@@ -24,7 +24,8 @@ var FailIfUnmatchedStructTags = false
 // in the csv header.
 var FailIfDoubleHeaderNames = false
 
-// Indicates whether we should align duplicate CSV headers per their alignment in the struct definition
+// ShouldAlignDuplicateHeadersWithStructFieldOrder indicates whether we should align duplicate CSV
+// headers per their alignment in the struct definition.
 var ShouldAlignDuplicateHeadersWithStructFieldOrder = false
 
 // TagSeparator defines seperator string for multiple csv tags in struct fields

--- a/decode.go
+++ b/decode.go
@@ -121,9 +121,15 @@ func readTo(decoder Decoder, out interface{}) error {
 
 	csvHeadersLabels := make(map[int]*fieldInfo, len(outInnerStructInfo.Fields)) // Used to store the correspondance header <-> position in CSV
 
+	headerCount := map[string]int{}
 	for i, csvColumnHeader := range headers {
-		if fieldInfo := getCSVFieldPosition(csvColumnHeader, outInnerStructInfo); fieldInfo != nil {
+		curHeaderCount := headerCount[csvColumnHeader]
+		if fieldInfo := getCSVFieldPosition(csvColumnHeader, outInnerStructInfo, curHeaderCount); fieldInfo != nil {
 			csvHeadersLabels[i] = fieldInfo
+			if ShouldAlignDuplicateHeadersWithStructFieldOrder {
+				curHeaderCount++
+				headerCount[csvColumnHeader] = curHeaderCount
+			}
 		}
 	}
 
@@ -175,9 +181,15 @@ func readEach(decoder SimpleDecoder, c interface{}) error {
 		return errors.New("no csv struct tags found")
 	}
 	csvHeadersLabels := make(map[int]*fieldInfo, len(outInnerStructInfo.Fields)) // Used to store the correspondance header <-> position in CSV
+	headerCount := map[string]int{}
 	for i, csvColumnHeader := range headers {
-		if fieldInfo := getCSVFieldPosition(csvColumnHeader, outInnerStructInfo); fieldInfo != nil {
+		curHeaderCount := headerCount[csvColumnHeader]
+		if fieldInfo := getCSVFieldPosition(csvColumnHeader, outInnerStructInfo, curHeaderCount); fieldInfo != nil {
 			csvHeadersLabels[i] = fieldInfo
+			if ShouldAlignDuplicateHeadersWithStructFieldOrder {
+				curHeaderCount++
+				headerCount[csvColumnHeader] = curHeaderCount
+			}
 		}
 	}
 	if err := maybeMissingStructFields(outInnerStructInfo.Fields, headers); err != nil {
@@ -254,10 +266,15 @@ func ensureOutCapacity(out *reflect.Value, csvLen int) error {
 	return nil
 }
 
-func getCSVFieldPosition(key string, structInfo *structInfo) *fieldInfo {
+func getCSVFieldPosition(key string, structInfo *structInfo, curHeaderCount int) *fieldInfo {
+	matchedFieldCount := 0
 	for _, field := range structInfo.Fields {
 		if field.matchesKey(key) {
-			return &field
+			if matchedFieldCount >= curHeaderCount {
+				return &field
+			} else {
+				matchedFieldCount++
+			}
 		}
 	}
 	return nil

--- a/decode_test.go
+++ b/decode_test.go
@@ -214,6 +214,21 @@ e,3,b`)
 	if samples[0].Foo != "baz" {
 		t.Fatal("Double header allowed, value should be of third row but is not. Function called is readTo.")
 	}
+
+	b = bytes.NewBufferString(`foo,BAR,foo
+f,1,baz
+e,3,b`)
+	d = &decoder{in: b}
+	ShouldAlignDuplicateHeadersWithStructFieldOrder = true
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+	// Double header allowed, value should be of first row
+	if samples[0].Foo != "f" {
+		t.Fatal("Double header allowed, value should be of first row but is not. Function called is readTo.")
+	}
+
+	ShouldAlignDuplicateHeadersWithStructFieldOrder = false
 	// Double header not allowed, should fail
 	FailIfDoubleHeaderNames = true
 	if err := readTo(d, &samples); err == nil {
@@ -223,8 +238,8 @@ e,3,b`)
 	// *** check readEach
 	FailIfDoubleHeaderNames = false
 	b = bytes.NewBufferString(`foo,BAR,foo
-	f,1,baz
-	e,3,b`)
+f,1,baz
+e,3,b`)
 	d = &decoder{in: b}
 	samples = samples[:0]
 	c := make(chan Sample)


### PR DESCRIPTION
struct field header in the destination struct definition and test. This PR provides a way to read values in columns with duplicate headers into structs with duplicate field tags. The duplicates are matched in order from top to bottom in the struct and from left to right in the csv sheet.