### PR TITLE
Use TagSeparator when marshalling.

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -38,7 +38,15 @@ var selfCSVWriter = DefaultCSVWriter
 
 // DefaultCSVWriter is the default CSV writer used to format CSV (cf. csv.NewWriter)
 func DefaultCSVWriter(out io.Writer) *csv.Writer {
-	return csv.NewWriter(out)
+	writer := csv.NewWriter(out)
+
+	// As only one rune can be defined as a CSV separator, we are going to trim
+	// the custom tag separator and use the first rune.
+	if runes := []rune(strings.TrimSpace(TagSeparator)); len(runes) > 0 {
+		writer.Comma = runes[0]
+	}
+
+	return writer
 }
 
 // SetCSVWriter sets the CSV writer used to format CSV.

--- a/encode_test.go
+++ b/encode_test.go
@@ -225,6 +225,28 @@ func TestRenamedTypesMarshal(t *testing.T) {
 	}
 }
 
+// TestCustomTagSeparatorMarshal tests for custom tag separator in marshalling.
+func TestCustomTagSeparatorMarshal(t *testing.T) {
+	samples := []RenamedSample{
+		{RenamedFloatUnmarshaler: 1.4, RenamedFloatDefault: 1.5},
+		{RenamedFloatUnmarshaler: 2.3, RenamedFloatDefault: 2.4},
+	}
+
+	TagSeparator = " | "
+	// Switch back to default TagSeparator after this
+	defer func () {
+		TagSeparator = ","
+	}()
+
+	csvContent, err := MarshalString(&samples)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if csvContent != "foo|bar\n1,4|1.5\n2,3|2.4\n" {
+		t.Fatalf("Error marshaling floats with , as separator. Expected \nfoo|bar\n1,4|1.5\n2,3|2.4\ngot:\n%v", csvContent)
+	}
+}
+
 func (rf *RenamedFloat64Unmarshaler) MarshalCSV() (csv string, err error) {
 	if *rf == RenamedFloat64Unmarshaler(4.2) {
 		return "", MarshalError{"Test error: Invalid float 4.2"}


### PR DESCRIPTION
The library was ignoring the global TagSeparator variable when marshalling a
struct. As only one rune can be defined as a CSV separator, we are going to
trim the custom tag separator and use the first rune.