### PR TITLE
Use CSVReader interface instead of csv.Reader

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -64,12 +64,12 @@ func getCSVWriter(out io.Writer) *csv.Writer {
 var selfCSVReader = DefaultCSVReader
 
 // DefaultCSVReader is the default CSV reader used to parse CSV (cf. csv.NewReader)
-func DefaultCSVReader(in io.Reader) *csv.Reader {
+func DefaultCSVReader(in io.Reader) CSVReader {
 	return csv.NewReader(in)
 }
 
 // LazyCSVReader returns a lazy CSV reader, with LazyQuotes and TrimLeadingSpace.
-func LazyCSVReader(in io.Reader) *csv.Reader {
+func LazyCSVReader(in io.Reader) CSVReader {
 	csvReader := csv.NewReader(in)
 	csvReader.LazyQuotes = true
 	csvReader.TrimLeadingSpace = true
@@ -77,11 +77,11 @@ func LazyCSVReader(in io.Reader) *csv.Reader {
 }
 
 // SetCSVReader sets the CSV reader used to parse CSV.
-func SetCSVReader(csvReader func(io.Reader) *csv.Reader) {
+func SetCSVReader(csvReader func(io.Reader) CSVReader) {
 	selfCSVReader = csvReader
 }
 
-func getCSVReader(in io.Reader) *csv.Reader {
+func getCSVReader(in io.Reader) CSVReader {
 	return selfCSVReader(in)
 }
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -326,7 +326,7 @@ func TestRenamedTypesUnmarshal(t *testing.T) {
 	var samples []RenamedSample
 
 	// Set different csv field separator to enable comma in floats
-	SetCSVReader(func(in io.Reader) *csv.Reader {
+	SetCSVReader(func(in io.Reader) CSVReader {
 		csvin := csv.NewReader(in)
 		csvin.Comma = ';'
 		return csvin
@@ -512,7 +512,7 @@ func TestCSVToMaps(t *testing.T) {
 }
 
 type trimDecoder struct {
-	csvReader *csv.Reader
+	csvReader CSVReader
 }
 
 func (c *trimDecoder) getCSVRow() ([]string, error) {


### PR DESCRIPTION
This just adds a bit to the previous PR: https://github.com/gocarina/gocsv/pull/47 by replacing a few occurrences of *csv.Reader with the interface CSVReader. It should let you use drop in replacements for encoding/csv in SetCSVReader and then call UnmarshalFile as usual. It works for my use case but feel free to close if it breaks something I haven't noticed.

