### PR TITLE
Improve marshalling/unmarshalling

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func Test_readTo(t *testing.T) {
@@ -58,6 +59,25 @@ e,BAD_INPUT,b`)
 		t.Fatalf("incorrect error type: %T", err)
 	}
 
+}
+
+func Test_readTo_Time(t *testing.T) {
+	b := bytes.NewBufferString(`Foo
+1970-01-01T03:01:00+03:00`)
+	d := &decoder{in: b}
+
+	var samples []DateTime
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+
+	rt, _ := time.Parse(time.RFC3339, "1970-01-01T03:01:00+03:00")
+
+	expected := DateTime{Foo: rt}
+
+	if !reflect.DeepEqual(expected, samples[0]) {
+		t.Fatalf("expected first sample %v, got %v", expected, samples[0])
+	}
 }
 
 func Test_readTo_complex_embed(t *testing.T) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func assertLine(t *testing.T, expected, actual []string) {
@@ -44,6 +45,35 @@ func Test_writeTo(t *testing.T) {
 	assertLine(t, []string{"foo", "BAR", "Baz", "Quux", "Blah", "SPtr"}, lines[0])
 	assertLine(t, []string{"f", "1", "baz", "0.1", "2", "*string"}, lines[1])
 	assertLine(t, []string{"e", "3", "b", "0.46153846153846156", "", ""}, lines[2])
+}
+
+func Test_writeTo_Time(t *testing.T) {
+	b := bytes.Buffer{}
+	e := &encoder{out: &b}
+	d := time.Unix(60, 0)
+	s := []DateTime{
+		{Foo: d},
+	}
+	if err := writeTo(csv.NewWriter(e.out), s, true); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, err := csv.NewReader(&b).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ft := time.Now()
+	ft.UnmarshalText([]byte(lines[0][0]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ft != d {
+		t.Fatalf("Dates doesn't match: %s and actual: %s", d, d)
+	}
+
+	m, _ := d.MarshalText()
+	assertLine(t, []string{string(m)}, lines[0])
 }
 
 func Test_writeTo_NoHeaders(t *testing.T) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -68,7 +68,7 @@ func Test_writeTo_Time(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ft != d {
+	if ft.Sub(d) != 0 {
 		t.Fatalf("Dates doesn't match: %s and actual: %s", d, d)
 	}
 

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -1,5 +1,7 @@
 package gocsv
 
+import "time"
+
 type Sample struct {
 	Foo  string  `csv:"foo"`
 	Bar  int     `csv:"BAR"`
@@ -40,4 +42,8 @@ type MultiTagSample struct {
 type TagSeparatorSample struct {
 	Foo string `csv:"Baz|foo"`
 	Bar int    `csv:"BAR"`
+}
+
+type DateTime struct {
+	Foo time.Time `csv:"Foo"`
 }

--- a/types.go
+++ b/types.go
@@ -414,11 +414,11 @@ func marshall(field reflect.Value) (value string, err error) {
 	marshallIt := func(finalField reflect.Value) (string, error) {
 		if finalField.CanInterface() && finalField.Type().Implements(marshallerType) { // Use TypeMarshaller when possible
 			return finalField.Interface().(TypeMarshaller).MarshalCSV()
-		} else if finalField.CanInterface() && finalField.Type().Implements(stringerType) { // Otherwise try to use Stringer
-			return finalField.Interface().(Stringer).String(), nil
 		} else if finalField.CanInterface() && finalField.Type().Implements(textMarshalerType) { // Otherwise try to use TextMarshaller
 			text, err := finalField.Interface().(encoding.TextMarshaler).MarshalText()
 			return string(text), err
+		} else if finalField.CanInterface() && finalField.Type().Implements(stringerType) { // Otherwise try to use Stringer
+			return finalField.Interface().(Stringer).String(), nil
 		}
 
 		return value, NoMarshalFuncError{"No known conversion from " + field.Type().String() + " to string, " + field.Type().String() + " does not implement TypeMarshaller nor Stringer"}


### PR DESCRIPTION
This commit makes the order of checking `textMarshalerType` and `stringerType` interfaces more concistent. This allows working with `time.Time` and other types without custom converters.