### PR TITLE
add handling for leading or trailing whitespace in header columns

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -13,7 +13,7 @@ type structInfo struct {
 	Fields []fieldInfo
 }
 
-// fieldInfo is a struct field that should be mapped to a CSV column, or vica-versa
+// fieldInfo is a struct field that should be mapped to a CSV column, or vice-versa
 // Each IndexChain element before the last is the index of an the embedded struct field
 // that defines Key as a tag
 type fieldInfo struct {
@@ -27,7 +27,7 @@ func (f fieldInfo) getFirstKey() string {
 
 func (f fieldInfo) matchesKey(key string) bool {
 	for _, k := range f.keys {
-		if key == k {
+		if key == k || strings.TrimSpace(key) == k {
 			return true
 		}
 	}


### PR DESCRIPTION
First, thanks for this awesome library! You just made my job a lot easier. Also, please be gentle. This is my first PR.

The reason for the pull request is as follows: When I was parsing a CSV, one of the column names kept getting omitted even though there was an appropriate tag on the struct I created. After some digging, I found that the header it was missing had trailing whitespace, which was causing matchesKeys to return false. I added a check for that in reflect.go, while retaining the original logic. I then ran the tests to make sure I hadn't broken anything, and the tests passed. I hope you will consider integrating this into the package itself.

Thanks!