### PR TITLE
Add support for 'omitempty' tags during decode

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -148,7 +148,7 @@ func readTo(decoder Decoder, out interface{}) error {
 		outInner := createNewOutInner(outInnerWasPointer, outInnerType)
 		for j, csvColumnContent := range csvRow {
 			if fieldInfo, ok := csvHeadersLabels[j]; ok { // Position found accordingly to header name
-				if err := setInnerField(&outInner, outInnerWasPointer, fieldInfo.IndexChain, csvColumnContent); err != nil { // Set field of struct
+				if err := setInnerField(&outInner, outInnerWasPointer, fieldInfo.IndexChain, csvColumnContent, fieldInfo.omitEmpty); err != nil { // Set field of struct
 					return &csv.ParseError{
 						Line:   i + 2, //add 2 to account for the header & 0-indexing of arrays
 						Column: j + 1,
@@ -213,7 +213,7 @@ func readEach(decoder SimpleDecoder, c interface{}) error {
 		outInner := createNewOutInner(outInnerWasPointer, outInnerType)
 		for j, csvColumnContent := range line {
 			if fieldInfo, ok := csvHeadersLabels[j]; ok { // Position found accordingly to header name
-				if err := setInnerField(&outInner, outInnerWasPointer, fieldInfo.IndexChain, csvColumnContent); err != nil { // Set field of struct
+				if err := setInnerField(&outInner, outInnerWasPointer, fieldInfo.IndexChain, csvColumnContent, fieldInfo.omitEmpty); err != nil { // Set field of struct
 					return &csv.ParseError{
 						Line:   i + 2, //add 2 to account for the header & 0-indexing of arrays
 						Column: j + 1,
@@ -287,10 +287,10 @@ func createNewOutInner(outInnerWasPointer bool, outInnerType reflect.Type) refle
 	return reflect.New(outInnerType).Elem()
 }
 
-func setInnerField(outInner *reflect.Value, outInnerWasPointer bool, index []int, value string) error {
+func setInnerField(outInner *reflect.Value, outInnerWasPointer bool, index []int, value string, omitEmpty bool) error {
 	oi := *outInner
 	if outInnerWasPointer {
 		oi = outInner.Elem()
 	}
-	return setField(oi.FieldByIndex(index), value)
+	return setField(oi.FieldByIndex(index), value, omitEmpty)
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -15,9 +15,9 @@ func Test_readTo(t *testing.T) {
 	blah := 0
 	sptr := "*string"
 	sptr2 := ""
-	b := bytes.NewBufferString(`foo,BAR,Baz,Blah,SPtr
-f,1,baz,,*string
-e,3,b,,`)
+	b := bytes.NewBufferString(`foo,BAR,Baz,Blah,SPtr,Omit
+f,1,baz,,*string,*string
+e,3,b,,,`)
 	d := &decoder{in: b}
 
 	var samples []Sample
@@ -28,7 +28,7 @@ e,3,b,,`)
 		t.Fatalf("expected 2 sample instances, got %d", len(samples))
 	}
 
-	expected := Sample{Foo: "f", Bar: 1, Baz: "baz", Blah: &blah, SPtr: &sptr}
+	expected := Sample{Foo: "f", Bar: 1, Baz: "baz", Blah: &blah, SPtr: &sptr, Omit: &sptr}
 	if !reflect.DeepEqual(expected, samples[0]) {
 		t.Fatalf("expected first sample %v, got %v", expected, samples[0])
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -42,9 +42,9 @@ func Test_writeTo(t *testing.T) {
 	if len(lines) != 3 {
 		t.Fatalf("expected 3 lines, got %d", len(lines))
 	}
-	assertLine(t, []string{"foo", "BAR", "Baz", "Quux", "Blah", "SPtr"}, lines[0])
-	assertLine(t, []string{"f", "1", "baz", "0.1", "2", "*string"}, lines[1])
-	assertLine(t, []string{"e", "3", "b", "0.46153846153846156", "", ""}, lines[2])
+	assertLine(t, []string{"foo", "BAR", "Baz", "Quux", "Blah", "SPtr", "Omit"}, lines[0])
+	assertLine(t, []string{"f", "1", "baz", "0.1", "2", "*string", ""}, lines[1])
+	assertLine(t, []string{"e", "3", "b", "0.46153846153846156", "", "", ""}, lines[2])
 }
 
 func Test_writeTo_Time(t *testing.T) {
@@ -96,8 +96,8 @@ func Test_writeTo_NoHeaders(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(lines))
 	}
-	assertLine(t, []string{"f", "1", "baz", "0.1", "2", "*string"}, lines[0])
-	assertLine(t, []string{"e", "3", "b", "0.46153846153846156", "", ""}, lines[1])
+	assertLine(t, []string{"f", "1", "baz", "0.1", "2", "*string", ""}, lines[0])
+	assertLine(t, []string{"e", "3", "b", "0.46153846153846156", "", "", ""}, lines[1])
 }
 
 func Test_writeTo_multipleTags(t *testing.T) {
@@ -149,8 +149,8 @@ func Test_writeTo_embed(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(lines))
 	}
-	assertLine(t, []string{"first", "foo", "BAR", "Baz", "Quux", "Blah", "SPtr", "garply", "last"}, lines[0])
-	assertLine(t, []string{"aaa", "f", "1", "baz", "0.2", "2", "*string", "3.141592653589793", "zzz"}, lines[1])
+	assertLine(t, []string{"first", "foo", "BAR", "Baz", "Quux", "Blah", "SPtr", "Omit", "garply", "last"}, lines[0])
+	assertLine(t, []string{"aaa", "f", "1", "baz", "0.2", "2", "*string", "", "3.141592653589793", "zzz"}, lines[1])
 }
 
 func Test_writeTo_complex_embed(t *testing.T) {
@@ -187,8 +187,8 @@ func Test_writeTo_complex_embed(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(lines))
 	}
-	assertLine(t, []string{"first", "foo", "BAR", "Baz", "Quux", "Blah", "SPtr", "garply", "last", "abc"}, lines[0])
-	assertLine(t, []string{"aaa", "bbb", "111", "ddd", "12000000000000000000000", "", "*string", "0.1", "fff", "hhh"}, lines[1])
+	assertLine(t, []string{"first", "foo", "BAR", "Baz", "Quux", "Blah", "SPtr", "Omit", "garply", "last", "abc"}, lines[0])
+	assertLine(t, []string{"aaa", "bbb", "111", "ddd", "12000000000000000000000", "", "*string", "", "0.1", "fff", "hhh"}, lines[1])
 }
 
 func Test_writeToChan(t *testing.T) {
@@ -215,10 +215,10 @@ func Test_writeToChan(t *testing.T) {
 	}
 	for i, l := range lines {
 		if i == 0 {
-			assertLine(t, []string{"foo", "BAR", "Baz", "Quux", "Blah", "SPtr"}, l)
+			assertLine(t, []string{"foo", "BAR", "Baz", "Quux", "Blah", "SPtr", "Omit"}, l)
 			continue
 		}
-		assertLine(t, []string{"f", strconv.Itoa(i - 1), "baz" + strconv.Itoa(i-1), strconv.FormatFloat(float64(i-1), 'f', -1, 64), "", "*string"}, l)
+		assertLine(t, []string{"f", strconv.Itoa(i - 1), "baz" + strconv.Itoa(i-1), strconv.FormatFloat(float64(i-1), 'f', -1, 64), "", "*string", ""}, l)
 	}
 }
 

--- a/reflect.go
+++ b/reflect.go
@@ -18,6 +18,7 @@ type structInfo struct {
 // that defines Key as a tag
 type fieldInfo struct {
 	keys       []string
+	omitEmpty  bool
 	IndexChain []int
 }
 
@@ -70,6 +71,8 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 		for _, fieldTagEntry := range fieldTags {
 			if fieldTagEntry != "omitempty" {
 				filteredTags = append(filteredTags, fieldTagEntry)
+			} else {
+				fieldInfo.omitEmpty = true
 			}
 		}
 

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -9,6 +9,7 @@ type Sample struct {
 	Frop float64 `csv:"Quux"`
 	Blah *int    `csv:"Blah"`
 	SPtr *string `csv:"SPtr"`
+	Omit *string `csv:"Omit,omitempty"`
 }
 
 type EmbedSample struct {

--- a/types.go
+++ b/types.go
@@ -205,8 +205,11 @@ func toFloat(in interface{}) (float64, error) {
 	return 0, fmt.Errorf("No known conversion from " + inValue.Type().String() + " to float")
 }
 
-func setField(field reflect.Value, value string) error {
+func setField(field reflect.Value, value string, omitEmpty bool) error {
 	if field.Kind() == reflect.Ptr {
+		if omitEmpty && value == "" {
+			return nil
+		}
 		if field.IsNil() {
 			field.Set(reflect.New(field.Type().Elem()))
 		}


### PR DESCRIPTION
While in CSV, omitempty doesnot make much sense for writing,
during reading it can be used to skip assigning empty values.
Now on read, if the field is a pointer and the `omitempty`
tag is provided, when the value is an empty string, the
field will remain nil.