### PR TITLE
do not allow chan type

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -231,11 +231,7 @@ func readEach(decoder SimpleDecoder, c interface{}) error {
 // Check if the outType is an array or a slice
 func ensureOutType(outType reflect.Type) error {
 	switch outType.Kind() {
-	case reflect.Slice:
-		fallthrough
-	case reflect.Chan:
-		fallthrough
-	case reflect.Array:
+	case reflect.Slice, reflect.Array:
 		return nil
 	}
 	return fmt.Errorf("cannot use " + outType.String() + ", only slice or array supported")


### PR DESCRIPTION
In current logic, if a `chan` type is passed in, after `fallthrough`, it will still return nil err.

The change is to only allow `slice` and `array` type