### PR TITLE
Speed up custom type (un)marshalling

### DIFF
--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,44 @@
+package gocsv
+
+import (
+	"reflect"
+	"testing"
+)
+
+type sampleTypeUnmarshaller struct {
+	val string
+}
+
+func (s *sampleTypeUnmarshaller) UnmarshalCSV(val string) error {
+	s.val = val
+	return nil
+}
+
+type sampleTextUnmarshaller struct {
+	val []byte
+}
+
+func (s *sampleTextUnmarshaller) UnmarshalText(text []byte) error {
+	s.val = text
+	return nil
+}
+
+func Benchmark_unmarshall_TypeUnmarshaller(b *testing.B) {
+	sample := sampleTypeUnmarshaller{}
+	val := reflect.ValueOf(&sample)
+	for n := 0; n < b.N; n++ {
+		if err := unmarshall(val, "foo"); err != nil {
+			b.Fatalf("unmarshall error: %s", err.Error())
+		}
+	}
+}
+
+func Benchmark_unmarshall_TextUnmarshaller(b *testing.B) {
+	sample := sampleTextUnmarshaller{}
+	val := reflect.ValueOf(&sample)
+	for n := 0; n < b.N; n++ {
+		if err := unmarshall(val, "foo"); err != nil {
+			b.Fatalf("unmarshall error: %s", err.Error())
+		}
+	}
+}

--- a/types_test.go
+++ b/types_test.go
@@ -14,6 +14,10 @@ func (s *sampleTypeUnmarshaller) UnmarshalCSV(val string) error {
 	return nil
 }
 
+func (s sampleTypeUnmarshaller) MarshalCSV() (string, error) {
+	return s.val, nil
+}
+
 type sampleTextUnmarshaller struct {
 	val []byte
 }
@@ -21,6 +25,16 @@ type sampleTextUnmarshaller struct {
 func (s *sampleTextUnmarshaller) UnmarshalText(text []byte) error {
 	s.val = text
 	return nil
+}
+
+func (s sampleTextUnmarshaller) MarshalText() ([]byte, error) {
+	return s.val, nil
+}
+
+type sampleStringer string
+
+func (s sampleStringer) String() string {
+	return string(s)
 }
 
 func Benchmark_unmarshall_TypeUnmarshaller(b *testing.B) {
@@ -39,6 +53,39 @@ func Benchmark_unmarshall_TextUnmarshaller(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		if err := unmarshall(val, "foo"); err != nil {
 			b.Fatalf("unmarshall error: %s", err.Error())
+		}
+	}
+}
+
+func Benchmark_marshall_TypeMarshaller(b *testing.B) {
+	sample := sampleTypeUnmarshaller{"foo"}
+	val := reflect.ValueOf(&sample)
+	for n := 0; n < b.N; n++ {
+		_, err := marshall(val)
+		if err != nil {
+			b.Fatalf("marshall error: %s", err.Error())
+		}
+	}
+}
+
+func Benchmark_marshall_TextMarshaller(b *testing.B) {
+	sample := sampleTextUnmarshaller{[]byte("foo")}
+	val := reflect.ValueOf(&sample)
+	for n := 0; n < b.N; n++ {
+		_, err := marshall(val)
+		if err != nil {
+			b.Fatalf("marshall error: %s", err.Error())
+		}
+	}
+}
+
+func Benchmark_marshall_Stringer(b *testing.B) {
+	sample := sampleStringer("foo")
+	val := reflect.ValueOf(&sample)
+	for n := 0; n < b.N; n++ {
+		_, err := marshall(val)
+		if err != nil {
+			b.Fatalf("marshall error: %s", err.Error())
 		}
 	}
 }


### PR DESCRIPTION
Replacing the [Type.Implements](https://golang.org/pkg/reflect/#Type) calls with a type assertion allows Go to cache the result of these evaluations, which leads to about a ~40% speed-up (in macOS benchmarking) when unmarshalling into a custom TypeUnmarshaller. See https://stackoverflow.com/questions/46837485/why-is-reflect-type-implements-so-much-slower-than-a-type-assertion for more background.

I found this via some 'pprof' analysis of an application that uses gocsv on fairly wide structs. Unmarshalling into custom types performed significantly more slowly than unmarshalling into native types. See https://github.com/clyphub/gocsv/pull/12.  The commit messages include some before/after benchmark outputs.