### PR TITLE
Add go.mod with v2 as module version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/gocarina/gocsv/v2


### PR DESCRIPTION
The latest version of go toolchain has added support for versioned
modules. This change adds a go.mod file with v2 as the version, to
enable use with vgo and the proposed go module system in the future.

I have chosen v2 as version as I see that a branch named v1 exists. If
this PR is merged, a tag named `v2.0.0` will also need to be created to
make `gocsv` work well with go module support.