### PR TITLE
Fix toBool() to ignore case when comparing strings

### DIFF
--- a/types.go
+++ b/types.go
@@ -89,12 +89,12 @@ func toBool(in interface{}) (bool, error) {
 	switch inValue.Kind() {
 	case reflect.String:
 		s := inValue.String()
-		switch s {
-		case "yes":
+		s = strings.TrimSpace(s)
+		if strings.EqualFold(s, "yes") {
 			return true, nil
-		case "no", "":
+		} else if strings.EqualFold(s, "no") || s == "" {
 			return false, nil
-		default:
+		} else {
 			return strconv.ParseBool(s)
 		}
 	case reflect.Bool:


### PR DESCRIPTION
- this comes per request from issue:
https://github.com/gocarina/gocsv/issues/92
- trim white space since it could allow for incorrect comparison as well
e.g. 'yes ' != 'yes'