### PR TITLE
add go.mod for migration to go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/gocarina/gocsv/v2
+module github.com/gocarina/gocsv


### PR DESCRIPTION
updated go.mod for migration to go module. Right now the project can't be used by go module project as the package name list is different to the import path and the github repo location. With this modification and adding a version tag like v2.0.0, the project would be usable by go module project.

Related issue:
https://github.com/gocarina/gocsv/issues/100