### PR TITLE
[pull request] embeded complex structures may have invalid indexChain

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -191,6 +191,45 @@ func Test_writeTo_complex_embed(t *testing.T) {
 	assertLine(t, []string{"aaa", "bbb", "111", "ddd", "12000000000000000000000", "", "*string", "", "0.1", "fff", "hhh"}, lines[1])
 }
 
+func Test_writeTo_complex_inner_struct_embed(t *testing.T) {
+	b := bytes.Buffer{}
+	e := &encoder{out: &b}
+	sfs := []Level0Struct{
+		{
+			Level0Field: level1Struct{
+				Level1Field: level2Struct{
+					InnerStruct{
+						BoolIgnoreField0: false,
+						BoolField1:       false,
+						StringField2:     "email1",
+					},
+				},
+			},
+		},
+		{
+			Level0Field: level1Struct{
+				Level1Field: level2Struct{
+					InnerStruct{
+						BoolIgnoreField0: false,
+						BoolField1:       true,
+						StringField2:     "email2",
+					},
+				},
+			},
+		},
+	}
+
+	if err := writeTo(NewSafeCSVWriter(csv.NewWriter(e.out)), sfs, true); err != nil {
+		t.Fatal(err)
+	}
+	lines, err := csv.NewReader(&b).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLine(t, []string{"false", "email1"}, lines[0])
+	assertLine(t, []string{"true", "email2"}, lines[1])
+}
+
 func Test_writeToChan(t *testing.T) {
 	b := bytes.Buffer{}
 	e := &encoder{out: &b}

--- a/reflect.go
+++ b/reflect.go
@@ -58,7 +58,10 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 		if field.PkgPath != "" {
 			continue
 		}
-		indexChain := append(parentIndexChain, i)
+
+		var cpy = make([]int, len(parentIndexChain))
+		copy(cpy, parentIndexChain)
+		indexChain := append(cpy, i)
 		// if the field is a struct, create a fieldInfo for each of its fields
 		if field.Type.Kind() == reflect.Struct {
 			fieldsList = append(fieldsList, getFieldInfos(field.Type, indexChain)...)

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -48,3 +48,21 @@ type TagSeparatorSample struct {
 type DateTime struct {
 	Foo time.Time `csv:"Foo"`
 }
+
+type Level0Struct struct {
+	Level0Field level1Struct `csv:"-"`
+}
+
+type level1Struct struct {
+	Level1Field level2Struct `csv:"-"`
+}
+
+type level2Struct struct {
+	InnerStruct
+}
+
+type InnerStruct struct {
+	BoolIgnoreField0 bool   `csv:"-"`
+	BoolField1       bool   `csv:"boolField1"`
+	StringField2     string `csv:"stringField2"`
+}


### PR DESCRIPTION
I've noticed that this lib works improperly with my structure, so I checked and found out that in some cases line `indexChain := append(parentIndexChain, i)` in `reflect.go` was responsible for replacing of `indexChain` across same structure in multiple fields. I fixed the problem and wrote tests with my own structures to reproduce the bug