### PR TITLE
Decoding for struct pointers

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -362,7 +362,16 @@ func createNewOutInner(outInnerWasPointer bool, outInnerType reflect.Type) refle
 func setInnerField(outInner *reflect.Value, outInnerWasPointer bool, index []int, value string, omitEmpty bool) error {
 	oi := *outInner
 	if outInnerWasPointer {
+		// initialize nil pointer
+		if oi.IsNil() {
+			setField(oi, "", omitEmpty)
+		}
 		oi = outInner.Elem()
+	}
+	// because pointers can be nil need to recurse one index at a time and perform nil check
+	if len(index) > 1 {
+		nextField := oi.Field(index[0])
+		return setInnerField(&nextField, nextField.Kind() == reflect.Ptr, index[1:], value, omitEmpty)
 	}
 	return setField(oi.FieldByIndex(index), value, omitEmpty)
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -125,6 +125,45 @@ ff,gg,22,hh,ii,jj`)
 	}
 }
 
+func Test_readTo_embed_ptr(t *testing.T) {
+	b := bytes.NewBufferString(`first,foo,BAR,Baz,last,abc
+aa,bb,11,cc,dd,ee
+ff,gg,22,hh,ii,jj`)
+	d := &decoder{in: b}
+	var rows []EmbedPtrSample
+	if err := readTo(d, &rows); err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := EmbedPtrSample{
+		Qux: "ff",
+		Sample: &Sample{
+			Foo: "gg",
+			Bar: 22,
+			Baz: "hh",
+		},
+		Quux: "ii",
+	}
+	if !reflect.DeepEqual(expected, rows[1]) {
+		t.Fatalf("expected first sample %v, got %+v", expected, rows[1])
+	}
+}
+
+func Test_readTo_embed_marshal(t *testing.T) {
+	b := bytes.NewBufferString(`foo
+bar`)
+	d := &decoder{in: b}
+	var rows []EmbedMarshal
+	if err := readTo(d, &rows); err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := EmbedMarshal{
+		Foo: &MarshalSample{Dummy: "bar"},
+	}
+	if !reflect.DeepEqual(expected, rows[0]) {
+		t.Fatalf("expected first sample %v, got %+v", expected, rows[1])
+	}
+}
+
 func Test_readEach(t *testing.T) {
 	b := bytes.NewBufferString(`first,foo,BAR,Baz,last,abc
 aa,bb,11,cc,dd,ee

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -27,7 +27,7 @@ type MarshalSample struct {
 func (m MarshalSample) MarshalText() ([]byte, error) {
 	return []byte(m.Dummy), nil
 }
-func (m *MarshalSample) UnmarhsalText(text []byte) error {
+func (m *MarshalSample) UnmarshalText(text []byte) error {
 	m.Dummy = string(text)
 	return nil
 }


### PR DESCRIPTION
Missed updating the `setInnerField` function in last PR. enables decoding into struct pointers. my bad about missing this in the first one