### PR TITLE
Allow unmarshaling without headers using a custom CSV reader

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -166,6 +166,11 @@ func UnmarshalWithoutHeaders(in io.Reader, out interface{}) error {
 	return readToWithoutHeaders(newDecoder(in), out)
 }
 
+// UnmarshalCSVWithoutHeaders parses a headerless CSV with passed in CSV reader
+func UnmarshalCSVWithoutHeaders(in CSVReader, out interface{}) error {
+	return readToWithoutHeaders(csvDecoder{in}, out)
+}
+
 // UnmarshalDecoder parses the CSV from the decoder in the interface
 func UnmarshalDecoder(in Decoder, out interface{}) error {
 	return readTo(in, out)

--- a/decode_test.go
+++ b/decode_test.go
@@ -633,3 +633,25 @@ e,3,b,,,,`)
 		t.Fatalf("expected second sample %v, got %v", expected, samples[1])
 	}
 }
+
+func TestUnmarshalCSVWithoutHeaders(t *testing.T) {
+	// tsv input to test custom csv reader
+	b := []byte("f\t1\tbaz\ne\t3\tblorp")
+	r := bytes.NewReader(b)
+	csvReader := csv.NewReader(r)
+	csvReader.Comma = '\t'
+
+	var samples []Sample
+	if err := UnmarshalCSVWithoutHeaders(csvReader, &samples); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := Sample{Foo: "f", Bar: 1, Baz: "baz"}
+	if !reflect.DeepEqual(expected, samples[0]) {
+		t.Fatalf("expected first sample %v, got %v", expected, samples[0])
+	}
+	expected = Sample{Foo: "e", Bar: 3, Baz: "blorp"}
+	if !reflect.DeepEqual(expected, samples[1]) {
+		t.Fatalf("expected second sample %v, got %v", expected, samples[1])
+	}
+}


### PR DESCRIPTION
Closes #109 

We use gocarina/gocsv for a program that supports both TSV and CSV in the same process. We need the ability to pass in a custom reader to the Unmarshal call without setting the global CSV reader. This is possible using the UnmarshalCSV function if you want headers but there was no equivalent of UnmarshalCSV for UnmarshalWithoutHeaders.