### PR TITLE
Fixes #119 -- made it possible to actually use the SimpleDecoder public interface

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -158,12 +158,12 @@ func UnmarshalBytes(in []byte, out interface{}) error {
 
 // Unmarshal parses the CSV from the reader in the interface.
 func Unmarshal(in io.Reader, out interface{}) error {
-	return readTo(newDecoder(in), out)
+	return readTo(newSimpleDecoderFromReader(in), out)
 }
 
 // UnmarshalWithoutHeaders parses the CSV from the reader in the interface.
 func UnmarshalWithoutHeaders(in io.Reader, out interface{}) error {
-	return readToWithoutHeaders(newDecoder(in), out)
+	return readToWithoutHeaders(newSimpleDecoderFromReader(in), out)
 }
 
 // UnmarshalCSVWithoutHeaders parses a headerless CSV with passed in CSV reader
@@ -187,7 +187,7 @@ func UnmarshalToChan(in io.Reader, c interface{}) error {
 	if c == nil {
 		return fmt.Errorf("goscv: channel is %v", c)
 	}
-	return readEach(newDecoder(in), c)
+	return readEach(newSimpleDecoderFromReader(in), c)
 }
 
 // UnmarshalDecoderToChan parses the CSV from the decoder and send each value in the chan c.
@@ -281,7 +281,7 @@ func UnmarshalStringToCallback(in string, c interface{}) (err error) {
 
 // CSVToMap creates a simple map from a CSV of 2 columns.
 func CSVToMap(in io.Reader) (map[string]string, error) {
-	decoder := newDecoder(in)
+	decoder := newSimpleDecoderFromReader(in)
 	header, err := decoder.getCSVRow()
 	if err != nil {
 		return nil, err

--- a/decode.go
+++ b/decode.go
@@ -16,26 +16,7 @@ type Decoder interface {
 // SimpleDecoder .
 type SimpleDecoder interface {
 	getCSVRow() ([]string, error)
-}
-
-type decoder struct {
-	in         io.Reader
-	csvDecoder *csvDecoder
-}
-
-func newDecoder(in io.Reader) *decoder {
-	return &decoder{in: in}
-}
-
-func (decode *decoder) getCSVRows() ([][]string, error) {
-	return getCSVReader(decode.in).ReadAll()
-}
-
-func (decode *decoder) getCSVRow() ([]string, error) {
-	if decode.csvDecoder == nil {
-		decode.csvDecoder = &csvDecoder{getCSVReader(decode.in)}
-	}
-	return decode.csvDecoder.Read()
+	getCSVRows() ([][]string, error)
 }
 
 type CSVReader interface {
@@ -45,6 +26,18 @@ type CSVReader interface {
 
 type csvDecoder struct {
 	CSVReader
+}
+
+func newSimpleDecoderFromReader(r io.Reader) SimpleDecoder {
+	return csvDecoder{getCSVReader(r)}
+}
+
+// NewSimpleDecoderFromCSVReader creates a SimpleDecoder, which may be passed
+// to the UnmarshalDecoder* family of functions, from a CSV reader. Note that
+// encoding/csv.Reader implements CSVReader, so you can pass one of those
+// directly here.
+func NewSimpleDecoderFromCSVReader(r CSVReader) SimpleDecoder {
+	return csvDecoder{r}
 }
 
 func (c csvDecoder) getCSVRows() ([][]string, error) {


### PR DESCRIPTION
This has the added side benefit of making it possible to simplify the internals of gocsv a tiny bit