### PR TITLE
Added header normalizer function

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -31,6 +31,21 @@ var ShouldAlignDuplicateHeadersWithStructFieldOrder = false
 // TagSeparator defines seperator string for multiple csv tags in struct fields
 var TagSeparator = ","
 
+// Normalizer is a function that takes and returns a string. It is applied to
+// struct and header field values before they are compared. It can be used to alter
+// names for comparison. For instance, you could allow case insensitive matching
+// or convert '-' to '_'.
+type Normalizer func(string) string
+
+// normalizeName function initially set to a nop Normalizer.
+var normalizeName = DefaultNameNormalizer()
+
+// DefaultNameNormalizer is a nop Normalizer.
+func DefaultNameNormalizer() Normalizer { return func(s string) string { return s } }
+
+// SetHeaderNormalizer sets the normalizer used to normalize struct and header field names.
+func SetHeaderNormalizer(f Normalizer) { normalizeName = f }
+
 // --------------------------------------------------------------------------
 // CSVWriter used to format CSV
 

--- a/decode.go
+++ b/decode.go
@@ -115,6 +115,15 @@ func maybeDoubleHeaderNames(headers []string) error {
 	return nil
 }
 
+// apply normalizer func to headers
+func normalizeHeaders(headers []string) []string {
+	out := make([]string, len(headers))
+	for i, h := range headers {
+		out[i] = normalizeName(h)
+	}
+	return out
+}
+
 func readTo(decoder Decoder, out interface{}) error {
 	outValue, outType := getConcreteReflectValueAndType(out) // Get the concrete type (not pointer) (Slice<?> or Array<?>)
 	if err := ensureOutType(outType); err != nil {
@@ -139,7 +148,7 @@ func readTo(decoder Decoder, out interface{}) error {
 		return errors.New("no csv struct tags found")
 	}
 
-	headers := csvRows[0]
+	headers := normalizeHeaders(csvRows[0])
 	body := csvRows[1:]
 
 	csvHeadersLabels := make(map[int]*fieldInfo, len(outInnerStructInfo.Fields)) // Used to store the correspondance header <-> position in CSV
@@ -190,6 +199,8 @@ func readEach(decoder SimpleDecoder, c interface{}) error {
 	if err != nil {
 		return err
 	}
+	headers = normalizeHeaders(headers)
+
 	outValue, outType := getConcreteReflectValueAndType(c) // Get the concrete type (not pointer) (Slice<?> or Array<?>)
 	if err := ensureOutType(outType); err != nil {
 		return err

--- a/reflect.go
+++ b/reflect.go
@@ -91,7 +91,7 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 		filteredTags := []string{}
 		for _, fieldTagEntry := range fieldTags {
 			if fieldTagEntry != "omitempty" {
-				filteredTags = append(filteredTags, fieldTagEntry)
+				filteredTags = append(filteredTags, normalizeName(fieldTagEntry))
 			} else {
 				fieldInfo.omitEmpty = true
 			}
@@ -102,7 +102,7 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 		} else if len(filteredTags) > 0 && filteredTags[0] != "" {
 			fieldInfo.keys = filteredTags
 		} else {
-			fieldInfo.keys = []string{field.Name}
+			fieldInfo.keys = []string{normalizeName(field.Name)}
 		}
 		fieldsList = append(fieldsList, fieldInfo)
 	}

--- a/unmarshaller.go
+++ b/unmarshaller.go
@@ -23,6 +23,7 @@ func NewUnmarshaller(reader *csv.Reader, out interface{}) (*Unmarshaller, error)
 	if err != nil {
 		return nil, err
 	}
+	headers = normalizeHeaders(headers)
 
 	um := &Unmarshaller{reader: reader, outType: reflect.TypeOf(out)}
 	err = validate(um, out, headers)


### PR DESCRIPTION
Function `normalizeName(string) string` is applied to both headers and struct field names before they are compared. Can be used to to allow case insensitive headers or headers that are not valid struct field names (e.g. change "-" to "_") that applies to all fields, without having to tag them individually.