### PR TITLE
Fix function name of comment

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -117,7 +117,7 @@ func Marshal(in interface{}, out io.Writer) (err error) {
 	return writeTo(writer, in, false)
 }
 
-// Marshal returns the CSV in writer from the interface.
+// MarshalWithoutHeaders returns the CSV in writer from the interface.
 func MarshalWithoutHeaders(in interface{}, out io.Writer) (err error) {
 	writer := getCSVWriter(out)
 	return writeTo(writer, in, true)

--- a/unmarshaller.go
+++ b/unmarshaller.go
@@ -42,7 +42,7 @@ func (um *Unmarshaller) Read() (interface{}, error) {
 	return um.unmarshalRow(row, nil)
 }
 
-// The same as Read(), but returns a map of the columns that didn't match a field in the struct
+// ReadUnmatched is same as Read(), but returns a map of the columns that didn't match a field in the struct
 func (um *Unmarshaller) ReadUnmatched() (interface{}, map[string]string, error) {
 	row, err := um.reader.Read()
 	if err != nil {


### PR DESCRIPTION
Comments should begin with the name of the function.
https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences