### PR TITLE
add a guard for maybeDoubleHeaderNames()

### DIFF
--- a/unmarshaller.go
+++ b/unmarshaller.go
@@ -81,8 +81,11 @@ func validate(um *Unmarshaller, s interface{}, headers []string) error {
 			}
 		}
 	}
-	if err := maybeDoubleHeaderNames(headers); err != nil {
-		return err
+
+	if FailIfDoubleHeaderNames {
+		if err := maybeDoubleHeaderNames(headers); err != nil {
+			return err
+		}
 	}
 
 	um.headerMap = csvHeaders


### PR DESCRIPTION
**Problem:** The CSV unmarshaller throws an error if duplicate header values are used in the CSV file. This is because when `maybeDoubleHeaderNames()` is called in the validate(); it doesn't check if `FailIfDoubleHeaderNames` is enabled/disabled. 

**Solution:** Check if `FailIfDoubleHeaderNames` is enabled before calling `maybeDoubleHeaderNames()`