### PR TITLE
Fix unmarshaling into slices

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -203,6 +203,27 @@ ff,gg,22,hh,ii,jj`)
 	}
 }
 
+func Test_readTo_slice(t *testing.T) {
+	b := bytes.NewBufferString(`Slice
+[]
+[1, 2, 3]`)
+	reader := csv.NewReader(b)
+	reader.Comma = '\t'
+	d := csvDecoder{reader}
+	samples := []SliceSample{}
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+	expected := SliceSample{Slice: []int{}}
+	if !reflect.DeepEqual(expected, samples[0]) {
+		t.Fatalf("expected first sample %v, got %v", expected, samples[0].Slice)
+	}
+	expected = SliceSample{Slice: []int{1, 2, 3}}
+	if !reflect.DeepEqual(expected, samples[1]) {
+		t.Fatalf("expected second sample %v, got %v", expected, samples[1].Slice)
+	}
+}
+
 func Test_readTo_embed_marshal(t *testing.T) {
 	b := bytes.NewBufferString(`foo
 bar`)

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -12,6 +12,10 @@ type Sample struct {
 	Omit *string `csv:"Omit,omitempty"`
 }
 
+type SliceSample struct {
+	Slice []int `csv:"Slice"`
+}
+
 type EmbedSample struct {
 	Qux string `csv:"first"`
 	Sample

--- a/types.go
+++ b/types.go
@@ -272,8 +272,7 @@ func setField(field reflect.Value, value string, omitEmpty bool) error {
 					return err
 				}
 				field.SetFloat(f)
-			case reflect.Slice:
-			case reflect.Struct:
+			case reflect.Slice, reflect.Struct:
 				err := json.Unmarshal([]byte(value), field.Addr().Interface())
 				if err != nil {
 					return err


### PR DESCRIPTION
This looked very much like an oversight that switch cases in Go don't fallthrough by default, even if they don't have any code of their own, unlike in certain other languages. Using the JSON-based unmarshaling method for both structs and slices works just fine, as shown by the test I added to make sure this keeps working.

… *if* you separate your values with something else than the default comma, that is…