### PR TITLE
Fix switch statement fall-through bug.

### DIFF
--- a/types.go
+++ b/types.go
@@ -289,8 +289,7 @@ func setField(field reflect.Value, value string, omitEmpty bool) error {
 
 func getFieldAsString(field reflect.Value) (str string, err error) {
 	switch field.Kind() {
-	case reflect.Interface:
-	case reflect.Ptr:
+	case reflect.Interface, reflect.Ptr:
 		if field.IsNil() {
 			return "", nil
 		}


### PR DESCRIPTION
If you pass in a struct full of `interface{}`s, only empty string is marshalled. C-style switch statements don't fall-through in Go.