### PR TITLE
[Proposal and Sample PR] Define a new function UnmarshalBytesToCallbackWithError

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -126,3 +126,13 @@ func getConcreteReflectValueAndType(in interface{}) (reflect.Value, reflect.Type
 	}
 	return value, value.Type()
 }
+
+var errorInterface = reflect.TypeOf((*error)(nil)).Elem()
+
+func isErrorType(outType reflect.Type) bool {
+	if outType.Kind() != reflect.Interface {
+		return false
+	}
+
+	return outType.Implements(errorInterface)
+}


### PR DESCRIPTION
Define a new function UnmarshalBytesToCallbackWithError, which allows Callback function to return an error.

If the callabck returns an error, the callback will not be called anymore. From the caller's perspective, the processing is stopped.   

If there is any callback error, it will returned to the caller as the return value of UnmarshalBytesToCallbackWithError

