### PR TITLE
Allow channel use with CSVToMaps

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -442,3 +442,28 @@ func CSVToMaps(reader io.Reader) ([]map[string]string, error) {
 	}
 	return rows, nil
 }
+
+// CSVToChanMaps parses the CSV from the reader and send a dictionary in the chan c, using the header row as the keys.
+func CSVToChanMaps(reader io.Reader, c chan <-map[string]string) error {
+	r := csv.NewReader(reader)
+	var header []string
+	for {
+		record, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if header == nil {
+			header = record
+		} else {
+			dict := map[string]string{}
+			for i := range header {
+				dict[header[i]] = record[i]
+			}
+			c <- dict
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
The use case is very specific, but in our side we've multiple big CSV files (~500mo), and we should retrieve dynamic headers.

CSVMaps was great but it require to load all the content into memory. This function is nearly the same as CSVMaps but accept another argument and push row into channel instead of a `[]map[string]string`