### PR TITLE
ignores child values with csv:"-" and includes upper level struct names if a csv tag is specified

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -105,8 +105,9 @@ func Test_writeTo_multipleTags(t *testing.T) {
 	e := &encoder{out: &b}
 	s := []MultiTagSample{
 		{Foo: "abc", Bar: 123},
-		{Foo: "def", Bar: 234, Ignored: 11},
+		{Foo: "def", Bar: 234, Ignored: TagSeparatorSample{Foo: "test", Bar: 5}},
 	}
+
 	if err := writeTo(NewSafeCSVWriter(csv.NewWriter(e.out)), s, false); err != nil {
 		t.Fatal(err)
 	}
@@ -300,8 +301,9 @@ func Test_writeTo_complex_inner_struct_embed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertLine(t, []string{"false", "email1"}, lines[0])
-	assertLine(t, []string{"true", "email2"}, lines[1])
+	if len(lines) > 0 {
+		t.Fatal("ignored parent structs should also ignore child values and structs")
+	}
 }
 
 func Test_writeToChan(t *testing.T) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -105,7 +105,7 @@ func Test_writeTo_multipleTags(t *testing.T) {
 	e := &encoder{out: &b}
 	s := []MultiTagSample{
 		{Foo: "abc", Bar: 123},
-		{Foo: "def", Bar: 234},
+		{Foo: "def", Bar: 234, Ignored: 11},
 	}
 	if err := writeTo(NewSafeCSVWriter(csv.NewWriter(e.out)), s, false); err != nil {
 		t.Fatal(err)

--- a/reflect.go
+++ b/reflect.go
@@ -63,6 +63,10 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 		copy(cpy, parentIndexChain)
 		indexChain := append(cpy, i)
 
+		fieldTag := field.Tag.Get("csv")
+		if fieldTag == "-" {
+			continue
+		}
 		// if the field is a pointer to a struct, follow the pointer then create fieldinfo for each field
 		if field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct {
 			// unless it implements marshalText or marshalCSV. Structs that implement this
@@ -79,8 +83,6 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 				fieldsList = append(fieldsList, getFieldInfos(field.Type, indexChain)...)
 			}
 		}
-
-		fieldTag := field.Tag.Get("csv")
 
 		// skips including the upper-level struct name unless a csv tag is specified
 		if field.Anonymous && fieldTag == "" {

--- a/reflect.go
+++ b/reflect.go
@@ -80,13 +80,14 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 			}
 		}
 
-		// if the field is an embedded struct, ignore the csv tag
-		if field.Anonymous {
+		fieldTag := field.Tag.Get("csv")
+
+		// skips including the upper-level struct name unless a csv tag is specified
+		if field.Anonymous && fieldTag == "" {
 			continue
 		}
 
 		fieldInfo := fieldInfo{IndexChain: indexChain}
-		fieldTag := field.Tag.Get("csv")
 		fieldTags := strings.Split(fieldTag, TagSeparator)
 		filteredTags := []string{}
 		for _, fieldTagEntry := range fieldTags {

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -64,8 +64,9 @@ type RenamedSample struct {
 }
 
 type MultiTagSample struct {
-	Foo string `csv:"Baz,foo"`
-	Bar int    `csv:"BAR"`
+	Foo     string `csv:"Baz,foo"`
+	Bar     int    `csv:"BAR"`
+	Ignored int    `csv:"-"`
 }
 
 type TagSeparatorSample struct {

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -64,9 +64,9 @@ type RenamedSample struct {
 }
 
 type MultiTagSample struct {
-	Foo     string `csv:"Baz,foo"`
-	Bar     int    `csv:"BAR"`
-	Ignored int    `csv:"-"`
+	Foo     string             `csv:"Baz,foo"`
+	Bar     int                `csv:"BAR"`
+	Ignored TagSeparatorSample `csv:"-"`
 }
 
 type TagSeparatorSample struct {


### PR DESCRIPTION
This should resolve:
https://github.com/gocarina/gocsv/issues/107


This continues to ignore the struct named fields unless a CSV tag is included

```
type test struct{
  Embedded struct {
     Name string
  } `csv:"embed"`
}
```

will now show up as embed,name. Where as before it would show up only as name


This also includes what might be a breaking change judging from one of the tests.

if a parent struct has `csv"-"`. then the child values are also ignored. 


I believe this will be a breaking change because the test https://github.com/gocarina/gocsv/blob/master/encode_test.go#L268 suggests that children of an ignored parent should be included