### PR TITLE
Properly cache structInfo

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 )
 
 // FailIfUnmatchedStructTags indicates whether it is considered an error when there is an unmatched
@@ -46,7 +47,11 @@ var normalizeName = DefaultNameNormalizer()
 func DefaultNameNormalizer() Normalizer { return func(s string) string { return s } }
 
 // SetHeaderNormalizer sets the normalizer used to normalize struct and header field names.
-func SetHeaderNormalizer(f Normalizer) { normalizeName = f }
+func SetHeaderNormalizer(f Normalizer) {
+	normalizeName = f
+	// Need to clear the cache hen the header normalizer changes.
+	structInfoCache = sync.Map{}
+}
 
 // --------------------------------------------------------------------------
 // CSVWriter used to format CSV

--- a/encode_test.go
+++ b/encode_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/csv"
 	"io"
+	"io/ioutil"
 	"math"
 	"strconv"
 	"strings"
@@ -405,4 +406,14 @@ type MarshalError struct {
 
 func (e MarshalError) Error() string {
 	return e.msg
+}
+
+func Benchmark_MarshalCSVWithoutHeaders(b *testing.B) {
+	dst := NewSafeCSVWriter(csv.NewWriter(ioutil.Discard))
+	for n := 0; n < b.N; n++ {
+		err := MarshalCSVWithoutHeaders([]Sample{{}}, dst)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/reflect.go
+++ b/reflect.go
@@ -35,19 +35,21 @@ func (f fieldInfo) matchesKey(key string) bool {
 	return false
 }
 
+var structInfoCache sync.Map
 var structMap = make(map[reflect.Type]*structInfo)
 var structMapMutex sync.RWMutex
 
 func getStructInfo(rType reflect.Type) *structInfo {
-	structMapMutex.RLock()
-	stInfo, ok := structMap[rType]
-	structMapMutex.RUnlock()
+	stInfo, ok := structInfoCache.Load(rType)
 	if ok {
-		return stInfo
+		return stInfo.(*structInfo)
 	}
+
 	fieldsList := getFieldInfos(rType, []int{})
 	stInfo = &structInfo{fieldsList}
-	return stInfo
+	structInfoCache.Store(rType, stInfo)
+
+	return stInfo.(*structInfo)
 }
 
 func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {


### PR DESCRIPTION
Previously we were checking the cache, but not actually reading from it. This makes Benchmark_MarshalCSVWithoutHeaders three times faster.