### PR TITLE
Feature add csv interface

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -540,6 +540,86 @@ func (rf *RenamedFloat64Unmarshaler) UnmarshalCSV(csv string) (err error) {
 	return nil
 }
 
+// TestUnmarshalCSVWithFields test that the TestUnmarshalCSVWithFields interface to marshall all the fields works
+func TestUnmarshalCSVWithFields(t *testing.T) {
+	b := []byte(`foo,bar,baz,frop
+bar,1,zip,3.14
+baz,2,zap,4.00`)
+	var samples []UnmarshalCSVWithFieldsSample
+	err := UnmarshalBytes(b, &samples)
+	if err != nil {
+		t.Fatalf("UnmarshalCSVWithFields() -> UnmarshalBytes() %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		index    int
+		wantFoo  string
+		wantBar  int
+		wantBaz  string
+		wantFrop float64
+	}{
+		{
+			name:     "should validate index 0",
+			index:    0,
+			wantFoo:  "bar",
+			wantBar:  1,
+			wantBaz:  "zip",
+			wantFrop: 314,
+		},
+		{
+			name:     "should validate index 1",
+			index:    1,
+			wantFoo:  "baz",
+			wantBar:  2,
+			wantBaz:  "zap",
+			wantFrop: 400,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if samples[tt.index].Foo != tt.wantFoo {
+				t.Fatalf("UnmarshalCSVWithFields() Index %d Foo expected %v got %v", tt.index, tt.wantFoo, samples[tt.index].Foo)
+			}
+
+			if samples[tt.index].Bar != tt.wantBar {
+				t.Fatalf("UnmarshalCSVWithFields() Index %d Bar expected %v got %v", tt.index, tt.wantBar, samples[tt.index].Bar)
+			}
+
+			if samples[tt.index].Baz != tt.wantBaz {
+				t.Fatalf("UnmarshalCSVWithFields() Index %d Baz expected %v got %v", tt.index, tt.wantBaz, samples[tt.index].Baz)
+			}
+
+			if samples[tt.index].Frop != tt.wantFrop {
+				t.Fatalf("UnmarshalCSVWithFields() Index %d Frop expected %v got %v", tt.index, tt.wantFrop, samples[tt.index].Frop)
+			}
+
+		})
+	}
+}
+
+func (u *UnmarshalCSVWithFieldsSample) UnmarshalCSVWithFields(key, value string) error {
+	switch key {
+	case "foo":
+		u.Foo = value
+	case "bar":
+		i, err := strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		u.Bar = i
+	case "baz":
+		u.Baz = value
+	case "frop":
+		f, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		u.Frop = f * 100
+	}
+	return nil
+}
+
 type UnmarshalError struct {
 	msg string
 }

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -99,3 +99,12 @@ type InnerStruct struct {
 	BoolField1       bool   `csv:"boolField1"`
 	StringField2     string `csv:"stringField2"`
 }
+
+var _ TypeUnmarshalCSVWithFields = (*UnmarshalCSVWithFieldsSample)(nil)
+
+type UnmarshalCSVWithFieldsSample struct {
+	Foo  string  `csv:"foo"`
+	Bar  int     `csv:"bar"`
+	Baz  string  `csv:"baz"`
+	Frop float64 `csv:"frop"`
+}

--- a/types.go
+++ b/types.go
@@ -25,6 +25,11 @@ type TypeUnmarshaller interface {
 	UnmarshalCSV(string) error
 }
 
+// TypeUnmarshalCSVWithFields can be implemented on whole structs to allow for whole structures to customized internal vs one off fields
+type TypeUnmarshalCSVWithFields interface {
+	UnmarshalCSVWithFields(key, value string) error
+}
+
 // NoUnmarshalFuncError is the custom error type to be raised in case there is no unmarshal function defined on type
 type NoUnmarshalFuncError struct {
 	msg string

--- a/types_test.go
+++ b/types_test.go
@@ -90,11 +90,11 @@ func Benchmark_marshall_Stringer(b *testing.B) {
 	}
 }
 
-func TestToInt(t *testing.T){
-	TestCase := []struct{
-		field string
+func TestToInt(t *testing.T) {
+	TestCase := []struct {
+		field  string
 		result int
-		err error
+		err    error
 	}{
 		{"123.2", 123, nil},
 		{"123", 123, nil},
@@ -102,12 +102,12 @@ func TestToInt(t *testing.T){
 		{"0.123", 0, nil},
 	}
 
-	for idx, item := range TestCase{
-		out, err:=toInt(item.field)
-		if err != nil{
+	for idx, item := range TestCase {
+		out, err := toInt(item.field)
+		if err != nil {
 			t.Fatal(err)
 		}
-		if int(out) != item.result{
+		if int(out) != item.result {
 			t.Fatal(idx, "result not equal")
 		}
 	}


### PR DESCRIPTION
I opened an issue recently asking for the ability to define a struct as have all it's fields customizable. This will reduce redundancy in needing to define separate types for fields within a struct. It also has the added benefit of allowing better abstractions in third party code dependency injections. 

Please review and confirm that the addition is sound and makes sense. 