### PR TITLE
fixed marshaling of string aliases

### DIFF
--- a/types.go
+++ b/types.go
@@ -300,8 +300,6 @@ func getFieldAsString(field reflect.Value) (str string, err error) {
 			return "", nil
 		}
 		return getFieldAsString(field.Elem())
-	case reflect.String:
-		return field.String(), nil
 	default:
 		// Check if field is go native type
 		switch field.Interface().(type) {

--- a/types_test.go
+++ b/types_test.go
@@ -37,6 +37,23 @@ func (s sampleStringer) String() string {
 	return string(s)
 }
 
+type customStringAlias string
+
+func (s customStringAlias) MarshalCSV() (string, error) {
+	return `"` + string(s) + `"`, nil
+}
+
+func Test_getFieldAsString_CustomStringAlias(t *testing.T) {
+	s, err := getFieldAsString(reflect.ValueOf(customStringAlias(("foo"))))
+	if err != nil {
+		t.Fatalf("getFieldAsString failure: %s", err)
+	}
+
+	if string(s) != `"foo"` {
+		t.Fatalf(`expected "foo" got %s`, s)
+	}
+}
+
 func Benchmark_unmarshall_TypeUnmarshaller(b *testing.B) {
 	sample := sampleTypeUnmarshaller{}
 	val := reflect.ValueOf(&sample)

--- a/types_test.go
+++ b/types_test.go
@@ -37,6 +37,7 @@ func (s sampleStringer) String() string {
 	return string(s)
 }
 
+type stringAlias string
 type customStringAlias string
 
 func (s customStringAlias) MarshalCSV() (string, error) {
@@ -44,13 +45,22 @@ func (s customStringAlias) MarshalCSV() (string, error) {
 }
 
 func Test_getFieldAsString_CustomStringAlias(t *testing.T) {
-	s, err := getFieldAsString(reflect.ValueOf(customStringAlias(("foo"))))
+	s, err := getFieldAsString(reflect.ValueOf(customStringAlias("foo")))
 	if err != nil {
 		t.Fatalf("getFieldAsString failure: %s", err)
 	}
 
 	if string(s) != `"foo"` {
 		t.Fatalf(`expected "foo" got %s`, s)
+	}
+
+	s, err = getFieldAsString(reflect.ValueOf(stringAlias("foo")))
+	if err != nil {
+		t.Fatalf("getFieldAsString failure: %s", err)
+	}
+
+	if string(s) != `foo` {
+		t.Fatalf(`expected foo got %s`, s)
 	}
 }
 


### PR DESCRIPTION
String aliases with custom marshalers were being ignored and only evaluated to the string value on line 303 before the custom marshaller was being called. Removing that line respects the marshalers and they are evaluated on line 339 without custom marshalers.