### PR TITLE
fix: Wrong Error Thrown When No Fields In Struct

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -154,7 +154,7 @@ func readToWithErrorHandler(decoder Decoder, errHandler ErrorHandler, out interf
 	}
 	outInnerStructInfo := getStructInfo(outInnerType) // Get the inner struct info to get CSV annotations
 	if len(outInnerStructInfo.Fields) == 0 {
-		return ErrEmptyCSVFile
+		return ErrNoStructTags
 	}
 
 	headers := normalizeHeaders(csvRows[0])


### PR DESCRIPTION
Little mistake on previous PR that sum up the errors into errors objects