### PR TITLE
Add an unmarshaling function for 2-column CSV into generic maps

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -901,3 +901,26 @@ func TestDecodeDefaultValues(t *testing.T) {
 		t.Fatalf("expected second sample %v, got %v", expected, out[0])
 	}
 }
+
+func TestUnmarshalCSVToMap(t *testing.T) {
+	b := []byte(`line	tokens
+10	["PRINT", "\"Hello map!\""]
+20	["GOTO", "10"]`)
+	r := bytes.NewReader(b)
+	csvReader := csv.NewReader(r)
+	csvReader.LazyQuotes = true
+	csvReader.Comma = '\t'
+
+	var sample map[int][]string
+	if err := UnmarshalCSVToMap(csvReader, &sample); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[int][]string{
+		10: {"PRINT", "\"Hello map!\""},
+		20: {"GOTO", "10"},
+	}
+	if !reflect.DeepEqual(expected, sample) {
+		t.Fatalf("expected %v, got %v", expected, sample)
+	}
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -924,3 +924,32 @@ func TestUnmarshalCSVToMap(t *testing.T) {
 		t.Fatalf("expected %v, got %v", expected, sample)
 	}
 }
+
+func BenchmarkCSVToMap(b *testing.B) {
+	bufstring := bytes.NewBufferString(`foo,BAR
+4,Jose
+2,Daniel
+5,Vincent`)
+	for n := 0; n < b.N; n++ {
+		_, err := CSVToMap(bytes.NewReader(bufstring.Bytes()))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalCSVToMap(b *testing.B) {
+	bufstring := []byte(`foo,BAR
+4,Jose
+2,Daniel
+5,Vincent`)
+	for n := 0; n < b.N; n++ {
+		var sample map[string]string
+		r := bytes.NewReader(bufstring)
+		d := csv.NewReader(r)
+		err := UnmarshalCSVToMap(d, &sample)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This is a generic version of CSVToMap, added in 969d259.

Also added a benchmark to compare this new function with the old CSVToMap. On my system, reflection introduces a performance drop of about 41% ([coincidence?](https://github.com/gocarina/gocsv#81)):

```
goos: windows
goarch: amd64
pkg: github.com/gocarina/gocsv
cpu: Intel(R) Core(TM) i5-8400T CPU @ 1.70GHz
BenchmarkCSVToMap-6         	442351	2409 ns/op
BenchmarkUnmarshalCSVToMap-6	284492	4089 ns/op
```

Therefore, I'm keeping the separate, non-reflection implementation of CSVToMap, rather than reimplementing it in terms of the new UnmarshalCSVToMap.