### PR TITLE
Trim whitespace when parsing csv tags

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -902,6 +902,27 @@ func TestDecodeDefaultValues(t *testing.T) {
 	}
 }
 
+func TestTrimTagWhitespace(t *testing.T) {
+	type whiteSpaceOptionStruct struct {
+		Foo *string `csv:"foo, omitempty"`
+		Bar int     `csv:"bar, default=13 "`
+	}
+	var out []whiteSpaceOptionStruct
+	b := bytes.NewBufferString(`foo,bar
+,`)
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	expected := whiteSpaceOptionStruct{
+		Foo: nil,
+		Bar: 13,
+	}
+
+	if !reflect.DeepEqual(expected, out[0]) {
+		t.Fatalf("expected sample %v, got %v", expected, out[0])
+	}
+}
+
 func TestUnmarshalCSVToMap(t *testing.T) {
 	b := []byte(`line	tokens
 10	["PRINT", "\"Hello map!\""]

--- a/reflect.go
+++ b/reflect.go
@@ -93,12 +93,13 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 		fieldTags := strings.Split(fieldTag, TagSeparator)
 		filteredTags := []string{}
 		for _, fieldTagEntry := range fieldTags {
-			if fieldTagEntry == "omitempty" {
+			trimmedFieldTagEntry := strings.TrimSpace(fieldTagEntry) // handles cases like `csv:"foo, omitempty, default=test"`
+			if trimmedFieldTagEntry == "omitempty" {
 				fieldInfo.omitEmpty = true
-			} else if strings.HasPrefix(fieldTagEntry, "default=") {
-				fieldInfo.defaultValue = strings.TrimPrefix(fieldTagEntry, "default=")
+			} else if strings.HasPrefix(trimmedFieldTagEntry, "default=") {
+				fieldInfo.defaultValue = strings.TrimPrefix(trimmedFieldTagEntry, "default=")
 			} else {
-				filteredTags = append(filteredTags, normalizeName(fieldTagEntry))
+				filteredTags = append(filteredTags, normalizeName(trimmedFieldTagEntry))
 			}
 		}
 


### PR DESCRIPTION
Observed no catch on variations in tag formatting, e.g. `csv:"foo, omitempty, default=16"`.  Implements light tweaks to ensure that `" , omitempty"` is treated the same as `",omitempty"` to deal with inconsistent behavior as observed in comment on #175
