### PR TITLE
feat: add header renormalization method

### DIFF
--- a/unmarshaller.go
+++ b/unmarshaller.go
@@ -118,6 +118,8 @@ func (um *Unmarshaller) unmarshalRow(row []string, unmatched map[string]string) 
 	return outValue.Interface(), nil
 }
 
+// RenormalizeHeaders will remap the header names based on the headerNormalizer.
+// This can be used to map a CSV to a struct where the CSV header names do not match in the file but a mapping is known
 func (um *Unmarshaller) RenormalizeHeaders(headerNormalizer func([]string) []string) error {
 	headers := um.Headers
 	if headerNormalizer != nil {

--- a/unmarshaller_test.go
+++ b/unmarshaller_test.go
@@ -45,3 +45,62 @@ c,d,e
 		t.Fatalf("Unepxected result from Read(): (%#v, %#v)", obj, err)
 	}
 }
+
+func TestUnmarshallerRenormalizeHeaders(t *testing.T) {
+	type sample struct {
+		FieldA string `csv:"field_a_map"`
+		FieldB string `csv:"field_b_map"`
+	}
+	const csvContents = `field_a,field_b
+a,b
+c,d,e
+`
+
+	headerNormalizer := func(headers []string) []string {
+		normalizedHeaders := make([]string, len(headers))
+		for i, header := range headers {
+			normalizedHeader := header
+			switch header {
+			case "field_a":
+				normalizedHeader = "field_a_map"
+			case "field_b":
+				normalizedHeader = "field_b_map"
+			}
+			normalizedHeaders[i] = normalizedHeader
+		}
+		return normalizedHeaders
+	}
+
+	reader := csv.NewReader(strings.NewReader(csvContents))
+	reader.FieldsPerRecord = -1
+	um, err := NewUnmarshaller(reader, sample{})
+	if err != nil {
+		t.Fatalf("Error calling NewUnmarshaller: %#v", err)
+	}
+
+	err = um.RenormalizeHeaders(headerNormalizer)
+	if err != nil {
+		t.Fatalf("Error calling RenormalizeHeaders: %#v", err)
+	}
+
+	obj, err := um.Read()
+	if err != nil {
+		t.Fatalf("Error calling Read(): %#v", err)
+	}
+	if obj.(sample).FieldA != "a" || obj.(sample).FieldB != "b" {
+		t.Fatalf("Unepxected result from Read(): %#v", obj)
+	}
+
+	obj, err = um.Read()
+	if err != nil {
+		t.Fatalf("Error calling Read(): %#v", err)
+	}
+	if obj.(sample).FieldA != "c" || obj.(sample).FieldB != "d" {
+		t.Fatalf("Unepxected result from Read(): %#v", obj)
+	}
+
+	obj, err = um.Read()
+	if err != io.EOF {
+		t.Fatalf("Unepxected result from Read(): (%#v, %#v)", obj, err)
+	}
+}


### PR DESCRIPTION
I have a use case where a team wants to read multiple CSVs files where the header column names may not be conforming to a specific schema.

In this case we want to have a custom mapping of header names without having to do 2 passes over the file to normalize the headers.

I have added a unit test demonstrating the use case.