### PR TITLE
Export decoder and simpleDecoder interface methods

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -219,7 +219,7 @@ func UnmarshalCSV(in CSVReader, out interface{}) error {
 // UnmarshalCSVToMap parses a CSV of 2 columns into a map.
 func UnmarshalCSVToMap(in CSVReader, out interface{}) error {
 	decoder := NewSimpleDecoderFromCSVReader(in)
-	header, err := decoder.getCSVRow()
+	header, err := decoder.GetCSVRow()
 	if err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func UnmarshalCSVToMap(in CSVReader, out interface{}) error {
 	for {
 		key := reflect.New(keyType)
 		value := reflect.New(valueType)
-		line, err := decoder.getCSVRow()
+		line, err := decoder.GetCSVRow()
 		if err == io.EOF {
 			break
 		} else if err != nil {
@@ -377,7 +377,7 @@ func UnmarshalToCallbackWithError(in io.Reader, f interface{}) error {
 		return fmt.Errorf("the given function must have exactly one return value")
 	}
 	if !isErrorType(t.Out(0)) {
-		return fmt.Errorf("the given function must only return error.")
+		return fmt.Errorf("the given function must only return error")
 	}
 
 	cerr := make(chan error)
@@ -445,7 +445,7 @@ func UnmarshalStringToCallbackWithError(in string, c interface{}) (err error) {
 // CSVToMap creates a simple map from a CSV of 2 columns.
 func CSVToMap(in io.Reader) (map[string]string, error) {
 	decoder := newSimpleDecoderFromReader(in)
-	header, err := decoder.getCSVRow()
+	header, err := decoder.GetCSVRow()
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +454,7 @@ func CSVToMap(in io.Reader) (map[string]string, error) {
 	}
 	m := make(map[string]string)
 	for {
-		line, err := decoder.getCSVRow()
+		line, err := decoder.GetCSVRow()
 		if err == io.EOF {
 			break
 		} else if err != nil {

--- a/decode.go
+++ b/decode.go
@@ -10,13 +10,13 @@ import (
 
 // Decoder .
 type Decoder interface {
-	getCSVRows() ([][]string, error)
+	GetCSVRows() ([][]string, error)
 }
 
 // SimpleDecoder .
 type SimpleDecoder interface {
-	getCSVRow() ([]string, error)
-	getCSVRows() ([][]string, error)
+	GetCSVRow() ([]string, error)
+	GetCSVRows() ([][]string, error)
 }
 
 type CSVReader interface {
@@ -45,11 +45,11 @@ func NewSimpleDecoderFromCSVReader(r CSVReader) SimpleDecoder {
 	return csvDecoder{r}
 }
 
-func (c csvDecoder) getCSVRows() ([][]string, error) {
+func (c csvDecoder) GetCSVRows() ([][]string, error) {
 	return c.ReadAll()
 }
 
-func (c csvDecoder) getCSVRow() ([]string, error) {
+func (c csvDecoder) GetCSVRow() ([]string, error) {
 	return c.Read()
 }
 
@@ -142,7 +142,7 @@ func readToWithErrorHandler(decoder Decoder, errHandler ErrorHandler, out interf
 	if err := ensureOutInnerType(outInnerType); err != nil {
 		return err
 	}
-	csvRows, err := decoder.getCSVRows() // Get the CSV csvRows
+	csvRows, err := decoder.GetCSVRows() // Get the CSV csvRows
 	if err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func readEach(decoder SimpleDecoder, c interface{}) error {
 	}
 	defer outValue.Close()
 
-	headers, err := decoder.getCSVRow()
+	headers, err := decoder.GetCSVRow()
 	if err != nil {
 		return err
 	}
@@ -280,7 +280,7 @@ func readEach(decoder SimpleDecoder, c interface{}) error {
 	}
 	i := 0
 	for {
-		line, err := decoder.getCSVRow()
+		line, err := decoder.GetCSVRow()
 		if err == io.EOF {
 			break
 		} else if err != nil {
@@ -322,7 +322,7 @@ func readEachWithoutHeaders(decoder SimpleDecoder, c interface{}) error {
 
 	i := 0
 	for {
-		line, err := decoder.getCSVRow()
+		line, err := decoder.GetCSVRow()
 		if err == io.EOF {
 			break
 		} else if err != nil {
@@ -354,7 +354,7 @@ func readToWithoutHeaders(decoder Decoder, out interface{}) error {
 	if err := ensureOutInnerType(outInnerType); err != nil {
 		return err
 	}
-	csvRows, err := decoder.getCSVRows() // Get the CSV csvRows
+	csvRows, err := decoder.GetCSVRows() // Get the CSV csvRows
 	if err != nil {
 		return err
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -784,7 +784,7 @@ type trimDecoder struct {
 	csvReader CSVReader
 }
 
-func (c *trimDecoder) getCSVRow() ([]string, error) {
+func (c *trimDecoder) GetCSVRow() ([]string, error) {
 	recoder, err := c.csvReader.Read()
 	for i, r := range recoder {
 		recoder[i] = strings.TrimRight(r, " ")
@@ -792,10 +792,10 @@ func (c *trimDecoder) getCSVRow() ([]string, error) {
 	return recoder, err
 }
 
-func (c *trimDecoder) getCSVRows() ([][]string, error) {
+func (c *trimDecoder) GetCSVRows() ([][]string, error) {
 	records := [][]string{}
 	for {
-		record, err := c.getCSVRow()
+		record, err := c.GetCSVRow()
 		if err == io.EOF {
 			break
 		} else if err != nil {


### PR DESCRIPTION
# Description

Export `Decoder` and `SimpleDecoder` interface methods.

# Why?

Current implementation is leaving `getCSVRow` and `getCSVRows` as private methods. Therefore, we have no way to implement a custom `SimpleDecoder` from outside of this package.

```sh
# go.myapi.com/example/golang/testpkg
golang/testpkg/csv_reader_adapter.go:31:9: cannot use &CSVDecoderAdapter{...} (type *CSVDecoderAdapter) as type gocsv.SimpleDecoder in return argument:
        *CSVDecoderAdapter does not implement gocsv.SimpleDecoder (missing gocsv.getCSVRow method)
                have getCSVRow() ([]string, error)
                want gocsv.getCSVRow() ([]string, error)
```

References: <https://groups.google.com/g/golang-nuts/c/6hpUErAfMHI>