### PR TITLE
Add function to marshal to channel omitting headers

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -150,7 +150,12 @@ func MarshalWithoutHeaders(in interface{}, out io.Writer) (err error) {
 
 // MarshalChan returns the CSV read from the channel.
 func MarshalChan(c <-chan interface{}, out CSVWriter) error {
-	return writeFromChan(out, c)
+	return writeFromChan(out, c, false)
+}
+
+// MarshalChanWithoutHeaders returns the CSV read from the channel.
+func MarshalChanWithoutHeaders(c <-chan interface{}, out CSVWriter) error {
+	return writeFromChan(out, c, true)
 }
 
 // MarshalCSV returns the CSV in writer from the interface.

--- a/encode.go
+++ b/encode.go
@@ -14,7 +14,7 @@ func newEncoder(out io.Writer) *encoder {
 	return &encoder{out}
 }
 
-func writeFromChan(writer CSVWriter, c <-chan interface{}) error {
+func writeFromChan(writer CSVWriter, c <-chan interface{}, omitHeaders bool) error {
 	// Get the first value. It wil determine the header structure.
 	firstValue, ok := <-c
 	if !ok {
@@ -30,8 +30,10 @@ func writeFromChan(writer CSVWriter, c <-chan interface{}) error {
 	for i, fieldInfo := range inInnerStructInfo.Fields { // Used to write the header (first line) in CSV
 		csvHeadersLabels[i] = fieldInfo.getFirstKey()
 	}
-	if err := writer.Write(csvHeadersLabels); err != nil {
-		return err
+	if !omitHeaders {
+		if err := writer.Write(csvHeadersLabels); err != nil {
+			return err
+		}
 	}
 	write := func(val reflect.Value) error {
 		for j, fieldInfo := range inInnerStructInfo.Fields {


### PR DESCRIPTION
Probably very niche in its use but I saw that most of the other functions have a `WithoutHeaders` counterpart so this is also for consistency.