### PR TITLE
Prefix fields of nested struct with tag of nested struct + .

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -224,6 +224,34 @@ func Test_readTo_slice(t *testing.T) {
 	}
 }
 
+func Test_readTo_slice_structs(t *testing.T) {
+	b := bytes.NewBufferString(`s[0].string,slice[0].f,slice[1].s,s[1].float,a[0].s,array[0].float,a[1].s,array[1].float,ints[0],ints[1],ints[2]
+s1,1.1,s2,2.2,s3,3.3,s4,4.4,1,2,3`)
+	d := newSimpleDecoderFromReader(b)
+
+	var samples []SliceStructSample
+	err := readTo(d, &samples)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	expected := SliceStructSample{
+		Slice: []SliceStruct{
+			{String: "s1", Float: 1.1},
+			{String: "s2", Float: 2.2},
+		},
+		SimpleSlice: []int{1, 2, 3},
+		Array: [2]SliceStruct{
+			{String: "s3", Float: 3.3},
+			{String: "s4", Float: 4.4},
+		},
+	}
+
+	if !reflect.DeepEqual(expected, samples[0]) {
+		t.Fatalf("expected \n  sample: %v\n     got: %v", expected, samples[0])
+	}
+}
+
 func Test_readTo_embed_marshal(t *testing.T) {
 	b := bytes.NewBufferString(`foo
 bar`)

--- a/decode_test.go
+++ b/decode_test.go
@@ -1002,3 +1002,37 @@ func BenchmarkUnmarshalCSVToMap(b *testing.B) {
 		}
 	}
 }
+
+func Test_readTo_nested_struct(t *testing.T) {
+	b := bytes.NewBufferString(`one.boolField1,one.stringField2,two.boolField1,two.stringField2,three.boolField1,three.stringField2
+false,email_one,true,email_two,false,email_three`)
+	d := newSimpleDecoderFromReader(b)
+
+	var samples []NestedSample
+	err := readTo(d, &samples)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	expected := NestedSample{
+		Inner1: InnerStruct{
+			BoolIgnoreField0: false,
+			BoolField1:       false,
+			StringField2:     "email_one",
+		},
+		Inner2: InnerStruct{
+			BoolIgnoreField0: false,
+			BoolField1:       true,
+			StringField2:     "email_two",
+		},
+		Inner3: NestedEmbedSample{InnerStruct{
+			BoolIgnoreField0: false,
+			BoolField1:       false,
+			StringField2:     "email_three",
+		}},
+	}
+
+	if !reflect.DeepEqual(expected, samples[0]) {
+		t.Fatalf("expected \n  sample: %v\n     got: %v", expected, samples[0])
+	}
+}

--- a/encode.go
+++ b/encode.go
@@ -140,6 +140,21 @@ func getInnerField(outInner reflect.Value, outInnerWasPointer bool, index []int)
 		}
 		oi = outInner.Elem()
 	}
+
+	if oi.Kind() == reflect.Slice || oi.Kind() == reflect.Array {
+		i := index[0]
+
+		if i >= oi.Len() {
+			return "", nil
+		}
+
+		item := oi.Index(i)
+		if len(index) > 1 {
+			return getInnerField(item, false, index[1:])
+		}
+		return getFieldAsString(item)
+	}
+
 	// because pointers can be nil need to recurse one index at a time and perform nil check
 	if len(index) > 1 {
 		nextField := oi.Field(index[0])

--- a/encode_test.go
+++ b/encode_test.go
@@ -125,6 +125,38 @@ func Test_writeTo_multipleTags(t *testing.T) {
 	assertLine(t, []string{"def", "234"}, lines[2])
 }
 
+func Test_writeTo_slice_structs(t *testing.T) {
+	b := bytes.Buffer{}
+	e := &encoder{out: &b}
+	s := []SliceStructSample{
+		{
+			Slice: []SliceStruct{
+				{String: "s1", Float: 1.1},
+				{String: "s2", Float: 2.2},
+				{String: "nope", Float: 3.3},
+			},
+			SimpleSlice: []int{1, 2, 3, 4, 5},
+			Array: [2]SliceStruct{
+				{String: "s3", Float: 3.3},
+				{String: "s4", Float: 4.4},
+			},
+		},
+	}
+	if err := writeTo(NewSafeCSVWriter(csv.NewWriter(e.out)), s, false); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, err := csv.NewReader(&b).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	assertLine(t, []string{"s[0].s", "s[0].f", "s[1].s", "s[1].f", "ints[0]", "ints[1]", "ints[2]", "a[0].s", "a[0].f", "a[1].s", "a[1].f"}, lines[0])
+	assertLine(t, []string{"s1", "1.1", "s2", "2.2", "1", "2", "3", "s3", "3.3", "s4", "4.4"}, lines[1])
+}
+
 func Test_writeTo_embed(t *testing.T) {
 	b := bytes.Buffer{}
 	e := &encoder{out: &b}

--- a/reflect.go
+++ b/reflect.go
@@ -1,7 +1,9 @@
 package gocsv
 
 import (
+	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -65,7 +67,6 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 		var cpy = make([]int, len(parentIndexChain))
 		copy(cpy, parentIndexChain)
 		indexChain := append(cpy, i)
-
 		// if the field is a pointer to a struct, follow the pointer then create fieldinfo for each field
 		if field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct {
 			// unless it implements marshalText or marshalCSV. Structs that implement this
@@ -88,16 +89,16 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 			continue
 		}
 
-		fieldInfo := fieldInfo{IndexChain: indexChain}
+		currFieldInfo := fieldInfo{IndexChain: indexChain}
 		fieldTag := field.Tag.Get(TagName)
 		fieldTags := strings.Split(fieldTag, TagSeparator)
 		filteredTags := []string{}
 		for _, fieldTagEntry := range fieldTags {
 			trimmedFieldTagEntry := strings.TrimSpace(fieldTagEntry) // handles cases like `csv:"foo, omitempty, default=test"`
 			if trimmedFieldTagEntry == "omitempty" {
-				fieldInfo.omitEmpty = true
+				currFieldInfo.omitEmpty = true
 			} else if strings.HasPrefix(trimmedFieldTagEntry, "default=") {
-				fieldInfo.defaultValue = strings.TrimPrefix(trimmedFieldTagEntry, "default=")
+				currFieldInfo.defaultValue = strings.TrimPrefix(trimmedFieldTagEntry, "default=")
 			} else {
 				filteredTags = append(filteredTags, normalizeName(trimmedFieldTagEntry))
 			}
@@ -106,11 +107,73 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 		if len(filteredTags) == 1 && filteredTags[0] == "-" {
 			continue
 		} else if len(filteredTags) > 0 && filteredTags[0] != "" {
-			fieldInfo.keys = filteredTags
+			currFieldInfo.keys = filteredTags
 		} else {
-			fieldInfo.keys = []string{normalizeName(field.Name)}
+			currFieldInfo.keys = []string{normalizeName(field.Name)}
 		}
-		fieldsList = append(fieldsList, fieldInfo)
+
+		if field.Type.Kind() == reflect.Slice || field.Type.Kind() == reflect.Array {
+			var arrayLength = -1
+			if arrayTag, ok := field.Tag.Lookup(TagName + "[]"); ok {
+				arrayLength, _ = strconv.Atoi(arrayTag)
+			}
+
+			// When the field is a slice/array of structs, create a fieldInfo for each index and each field
+			if field.Type.Elem().Kind() == reflect.Struct {
+				fieldInfos := getFieldInfos(field.Type.Elem(), []int{})
+
+				for idx := 0; idx < arrayLength; idx++ {
+					// copy index chain and append array index
+					var cpy2 = make([]int, len(indexChain))
+					copy(cpy2, indexChain)
+					arrayIndexChain := append(cpy2, idx)
+					for _, childFieldInfo := range fieldInfos {
+						// copy array index chain and append array index
+						var cpy3 = make([]int, len(arrayIndexChain))
+						copy(cpy3, arrayIndexChain)
+
+						arrayFieldInfo := fieldInfo{
+							IndexChain:   append(cpy3, childFieldInfo.IndexChain...),
+							omitEmpty:    childFieldInfo.omitEmpty,
+							defaultValue: childFieldInfo.defaultValue,
+						}
+
+						// create cartesian product of keys
+						// eg: array field keys x struct field keys
+						for _, akey := range currFieldInfo.keys {
+							for _, fkey := range childFieldInfo.keys {
+								arrayFieldInfo.keys = append(arrayFieldInfo.keys, normalizeName(fmt.Sprintf("%s[%d].%s", akey, idx, fkey)))
+							}
+						}
+
+						fieldsList = append(fieldsList, arrayFieldInfo)
+					}
+				}
+			} else if arrayLength > 0 {
+				// When the field is a slice/array of primitives, create a fieldInfo for each index
+				for idx := 0; idx < arrayLength; idx++ {
+					// copy index chain and append array index
+					var cpy2 = make([]int, len(indexChain))
+					copy(cpy2, indexChain)
+
+					arrayFieldInfo := fieldInfo{
+						IndexChain:   append(cpy2, idx),
+						omitEmpty:    currFieldInfo.omitEmpty,
+						defaultValue: currFieldInfo.defaultValue,
+					}
+
+					for _, akey := range currFieldInfo.keys {
+						arrayFieldInfo.keys = append(arrayFieldInfo.keys, normalizeName(fmt.Sprintf("%s[%d]", akey, idx)))
+					}
+
+					fieldsList = append(fieldsList, arrayFieldInfo)
+				}
+			} else {
+				fieldsList = append(fieldsList, currFieldInfo)
+			}
+		} else {
+			fieldsList = append(fieldsList, currFieldInfo)
+		}
 	}
 	return fieldsList
 }

--- a/reflect.go
+++ b/reflect.go
@@ -48,14 +48,14 @@ func getStructInfo(rType reflect.Type) *structInfo {
 		return stInfo.(*structInfo)
 	}
 
-	fieldsList := getFieldInfos(rType, []int{})
+	fieldsList := getFieldInfos(rType, []int{}, []string{})
 	stInfo = &structInfo{fieldsList}
 	structInfoCache.Store(rType, stInfo)
 
 	return stInfo.(*structInfo)
 }
 
-func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
+func getFieldInfos(rType reflect.Type, parentIndexChain []int, parentKeys []string) []fieldInfo {
 	fieldsCount := rType.NumField()
 	fieldsList := make([]fieldInfo, 0, fieldsCount)
 	for i := 0; i < fieldsCount; i++ {
@@ -67,49 +67,70 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 		var cpy = make([]int, len(parentIndexChain))
 		copy(cpy, parentIndexChain)
 		indexChain := append(cpy, i)
-		// if the field is a pointer to a struct, follow the pointer then create fieldinfo for each field
-		if field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct {
-			// unless it implements marshalText or marshalCSV. Structs that implement this
-			// should result in one value and not have their fields exposed
-			if !(canMarshal(field.Type.Elem())) {
-				fieldsList = append(fieldsList, getFieldInfos(field.Type.Elem(), indexChain)...)
+
+		var currFieldInfo *fieldInfo
+		if !field.Anonymous {
+			currFieldInfo = &fieldInfo{IndexChain: indexChain}
+			fieldTag := field.Tag.Get(TagName)
+			fieldTags := strings.Split(fieldTag, TagSeparator)
+			filteredTags := []string{}
+			for _, fieldTagEntry := range fieldTags {
+				trimmedFieldTagEntry := strings.TrimSpace(fieldTagEntry) // handles cases like `csv:"foo, omitempty, default=test"`
+				if trimmedFieldTagEntry == "omitempty" {
+					currFieldInfo.omitEmpty = true
+				} else if strings.HasPrefix(trimmedFieldTagEntry, "default=") {
+					currFieldInfo.defaultValue = strings.TrimPrefix(trimmedFieldTagEntry, "default=")
+				} else {
+					filteredTags = append(filteredTags, normalizeName(trimmedFieldTagEntry))
+				}
+			}
+
+			if len(filteredTags) == 1 && filteredTags[0] == "-" {
+				// ignore nested structs with - tag
+				continue
+			} else if len(filteredTags) > 0 && filteredTags[0] != "" {
+				currFieldInfo.keys = filteredTags
+			} else {
+				currFieldInfo.keys = []string{normalizeName(field.Name)}
+			}
+
+			if len(parentKeys) > 0 && currFieldInfo != nil {
+				// create cartesian product of keys
+				// eg: parent keys x field keys
+				keys := make([]string, 0, len(parentKeys)*len(currFieldInfo.keys))
+				for _, pkey := range parentKeys {
+					for _, ckey := range currFieldInfo.keys {
+						keys = append(keys, normalizeName(fmt.Sprintf("%s.%s", pkey, ckey)))
+					}
+				}
+				currFieldInfo.keys = keys
 			}
 		}
+
+		// handle struct
+		fieldType := field.Type
+		// if the field is a pointer, follow the pointer
+		if fieldType.Kind() == reflect.Ptr {
+			fieldType = fieldType.Elem()
+		}
 		// if the field is a struct, create a fieldInfo for each of its fields
-		if field.Type.Kind() == reflect.Struct {
+		if fieldType.Kind() == reflect.Struct {
 			// unless it implements marshalText or marshalCSV. Structs that implement this
 			// should result in one value and not have their fields exposed
-			if !(canMarshal(field.Type)) {
-				fieldsList = append(fieldsList, getFieldInfos(field.Type, indexChain)...)
+			if !(canMarshal(fieldType)) {
+				// if the field is an embedded struct, pass along parent keys
+				keys := parentKeys
+				if currFieldInfo != nil {
+					keys = currFieldInfo.keys
+				}
+				fieldsList = append(fieldsList, getFieldInfos(fieldType, indexChain, keys)...)
+				continue
 			}
 		}
 
 		// if the field is an embedded struct, ignore the csv tag
-		if field.Anonymous {
+		if currFieldInfo == nil {
 			continue
-		}
-
-		currFieldInfo := fieldInfo{IndexChain: indexChain}
-		fieldTag := field.Tag.Get(TagName)
-		fieldTags := strings.Split(fieldTag, TagSeparator)
-		filteredTags := []string{}
-		for _, fieldTagEntry := range fieldTags {
-			trimmedFieldTagEntry := strings.TrimSpace(fieldTagEntry) // handles cases like `csv:"foo, omitempty, default=test"`
-			if trimmedFieldTagEntry == "omitempty" {
-				currFieldInfo.omitEmpty = true
-			} else if strings.HasPrefix(trimmedFieldTagEntry, "default=") {
-				currFieldInfo.defaultValue = strings.TrimPrefix(trimmedFieldTagEntry, "default=")
-			} else {
-				filteredTags = append(filteredTags, normalizeName(trimmedFieldTagEntry))
-			}
-		}
-
-		if len(filteredTags) == 1 && filteredTags[0] == "-" {
-			continue
-		} else if len(filteredTags) > 0 && filteredTags[0] != "" {
-			currFieldInfo.keys = filteredTags
-		} else {
-			currFieldInfo.keys = []string{normalizeName(field.Name)}
 		}
 
 		if field.Type.Kind() == reflect.Slice || field.Type.Kind() == reflect.Array {
@@ -120,7 +141,7 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 
 			// When the field is a slice/array of structs, create a fieldInfo for each index and each field
 			if field.Type.Elem().Kind() == reflect.Struct {
-				fieldInfos := getFieldInfos(field.Type.Elem(), []int{})
+				fieldInfos := getFieldInfos(field.Type.Elem(), []int{}, []string{})
 
 				for idx := 0; idx < arrayLength; idx++ {
 					// copy index chain and append array index
@@ -169,10 +190,10 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 					fieldsList = append(fieldsList, arrayFieldInfo)
 				}
 			} else {
-				fieldsList = append(fieldsList, currFieldInfo)
+				fieldsList = append(fieldsList, *currFieldInfo)
 			}
 		} else {
-			fieldsList = append(fieldsList, currFieldInfo)
+			fieldsList = append(fieldsList, *currFieldInfo)
 		}
 	}
 	return fieldsList

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -94,11 +94,11 @@ type DateTime struct {
 }
 
 type Level0Struct struct {
-	Level0Field level1Struct `csv:"-"`
+	Level0Field level1Struct
 }
 
 type level1Struct struct {
-	Level1Field level2Struct `csv:"-"`
+	Level1Field level2Struct
 }
 
 type level2Struct struct {
@@ -118,4 +118,14 @@ type UnmarshalCSVWithFieldsSample struct {
 	Bar  int     `csv:"bar"`
 	Baz  string  `csv:"baz"`
 	Frop float64 `csv:"frop"`
+}
+
+type NestedSample struct {
+	Inner1      InnerStruct       `csv:"one"`
+	Inner2      InnerStruct       `csv:"two"`
+	InnerIgnore InnerStruct       `csv:"-"`
+	Inner3      NestedEmbedSample `csv:"three"`
+}
+type NestedEmbedSample struct {
+	InnerStruct
 }

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -16,6 +16,17 @@ type SliceSample struct {
 	Slice []int `csv:"Slice"`
 }
 
+type SliceStructSample struct {
+	Slice       []SliceStruct  `csv:"s,slice" csv[]:"2"`
+	SimpleSlice []int          `csv:"ints" csv[]:"3"`
+	Array       [2]SliceStruct `csv:"a,array" csv[]:"2"`
+}
+
+type SliceStruct struct {
+	String string  `csv:"s,string"`
+	Float  float64 `csv:"f,float"`
+}
+
 type EmbedSample struct {
 	Qux string `csv:"first"`
 	Sample


### PR DESCRIPTION
This makes it possible to prefix nested struct fields with the tag of the struct.
This also fixes #107 and #168

```
type NestedSample struct {
	Inner1      InnerStruct       `csv:"one"`
	InnerIgnore InnerStruct       `csv:"-"`
	Inner2      InnerStruct       `csv:"two"`
}

type InnerStruct struct {
	String string `csv:"string"`
}
```

When marshaling/unmarshaling `NestedSample` the following headers will be used:
```
one.string,two.string
```

Note: This PR builds on my first PR #207.
