### PR TITLE
Fixed issue with unmarshalling slice of structs that is empty

### DIFF
--- a/types.go
+++ b/types.go
@@ -280,6 +280,10 @@ func setField(field reflect.Value, value string, omitEmpty bool) error {
 				}
 				field.SetFloat(f)
 			case reflect.Slice, reflect.Struct:
+				if value == "" {
+					return nil
+				}
+
 				err := json.Unmarshal([]byte(value), field.Addr().Interface())
 				if err != nil {
 					return err

--- a/unmarshaller_test.go
+++ b/unmarshaller_test.go
@@ -1,6 +1,7 @@
 package gocsv
 
 import (
+	"bytes"
 	"encoding/csv"
 	"io"
 	"strings"
@@ -43,6 +44,54 @@ c,d,e
 	obj, err = um.Read()
 	if err != io.EOF {
 		t.Fatalf("Unepxected result from Read(): (%#v, %#v)", obj, err)
+	}
+}
+
+func TestUnmarshalListOfStructsAfterMarshal(t *testing.T) {
+
+	type Additional struct {
+		Value string
+	}
+
+	type Option struct {
+		Additional []*Additional
+		Key        string
+	}
+
+	inData := []*Option{
+		{
+			Key: "test",
+		},
+	}
+
+	// First, marshal our test data to a CSV format
+	buffer := new(bytes.Buffer)
+	innerWriter := csv.NewWriter(buffer)
+	innerWriter.Comma = '|'
+	csvWriter := NewSafeCSVWriter(innerWriter)
+	if err := MarshalCSV(inData, csvWriter); err != nil {
+		t.Fatalf("Error marshalling data to CSV: %#v", err)
+	}
+
+	if string(buffer.Bytes()) != "Additional|Key\n|test\n" {
+		t.Fatalf("Marshalled data had an unexpected form of %s", buffer.Bytes())
+	}
+
+	// Next, attempt to unmarshal our test data from a CSV format
+	var outData []*Option
+	innerReader := csv.NewReader(buffer)
+	innerReader.Comma = '|'
+	if err := UnmarshalCSV(innerReader, &outData); err != nil {
+		t.Fatalf("Error unmarshalling data from CSV: %#v", err)
+	}
+
+	// Finally, verify the data
+	if len(outData) != 1 {
+		t.Fatalf("Data expected to have one entry, had %d entries", len(outData))
+	} else if len(outData[0].Additional) != 0 {
+		t.Fatalf("Data Additional field expected to be empty, had length of %d", len(outData[0].Additional))
+	} else if outData[0].Key != "test" {
+		t.Fatalf("Data Key field did not contain expected value, had %q", outData[0].Key)
 	}
 }
 


### PR DESCRIPTION
This PR fixes Issue #214 by short-circuiting JSON-unmarshal for structs and slices in the case where the column name is empty.