### PR TITLE
Fixed issue with MarshalCSV of pointer type not marshalling properly

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -260,6 +260,41 @@ func Test_writeTo_embedmarshal(t *testing.T) {
 
 }
 
+func Test_writeTo_embedmarshalCSV(t *testing.T) {
+
+	// First, create our test data
+	b := new(bytes.Buffer)
+	e := &encoder{out: b}
+	s := []*EmbedMarshalCSV{
+		{
+			Symbol: "test",
+			Timestamp: &MarshalCSVSample{
+				Seconds: 1656460798,
+				Nanos:   693201614,
+			},
+		},
+	}
+
+	// Next, attempt to write our test data to a CSV format
+	if err := writeTo(NewSafeCSVWriter(csv.NewWriter(e.out)), s, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now, read in the data we just wrote
+	lines, err := csv.NewReader(b).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Finally, verify the structure of the data
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+
+	assertLine(t, []string{"symbol", "timestamp"}, lines[0])
+	assertLine(t, []string{"test", "1656460798693201614"}, lines[1])
+}
+
 func Test_writeTo_complex_embed(t *testing.T) {
 	b := bytes.Buffer{}
 	e := &encoder{out: &b}

--- a/reflect.go
+++ b/reflect.go
@@ -71,7 +71,7 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 		if field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct {
 			// unless it implements marshalText or marshalCSV. Structs that implement this
 			// should result in one value and not have their fields exposed
-			if !(canMarshal(field.Type.Elem())) {
+			if !(canMarshal(field.Type.Elem()) || canMarshal(field.Type)) {
 				fieldsList = append(fieldsList, getFieldInfos(field.Type.Elem(), indexChain)...)
 			}
 		}

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -1,6 +1,9 @@
 package gocsv
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 type Sample struct {
 	Foo  string  `csv:"foo"`
@@ -49,6 +52,24 @@ func (m *MarshalSample) UnmarshalText(text []byte) error {
 
 type EmbedMarshal struct {
 	Foo *MarshalSample `csv:"foo"`
+}
+
+type MarshalCSVSample struct {
+	Seconds int64
+	Nanos   int32
+}
+
+func (timestamp *MarshalCSVSample) MarshalCSV() (string, error) {
+	if timestamp == nil {
+		return "", nil
+	}
+
+	return fmt.Sprintf("%d%09d", timestamp.Seconds, timestamp.Nanos), nil
+}
+
+type EmbedMarshalCSV struct {
+	Symbol    string            `csv:"symbol"`
+	Timestamp *MarshalCSVSample `csv:"timestamp"`
 }
 
 type EmbedPtrSample struct {


### PR DESCRIPTION
This pull request fixes an issue wherein `MarshalCSV` was implemented on pointers-to-structs rather than the structs themselves, causing the `writeTo` function to ignore the definition. This addresses issue #216.