### PR TITLE
Added marshal support for untagged slices

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -35,6 +35,10 @@ var TagName = "csv"
 // TagSeparator defines seperator string for multiple csv tags in struct fields
 var TagSeparator = ","
 
+// SecondayComma shall be used when marshalling/unmarshalling slices and lists
+// of primitives for which the appropriate tags have not been defined
+var SecondaryComma = ";"
+
 // Normalizer is a function that takes and returns a string. It is applied to
 // struct and header field values before they are compared. It can be used to alter
 // names for comparison. For instance, you could allow case insensitive matching

--- a/encode_test.go
+++ b/encode_test.go
@@ -125,6 +125,44 @@ func Test_writeTo_multipleTags(t *testing.T) {
 	assertLine(t, []string{"def", "234"}, lines[2])
 }
 
+func Test_writeTo_slice(t *testing.T) {
+	b := bytes.Buffer{}
+	e := &encoder{out: &b}
+
+	type TestType struct {
+		Key   string
+		Items []int
+	}
+
+	s := []TestType{
+		{
+			Key:   "test1",
+			Items: []int{1, 2, 3},
+		},
+		{
+			Key:   "test2",
+			Items: []int{4, 5, 6},
+		},
+	}
+
+	if err := writeTo(NewSafeCSVWriter(csv.NewWriter(e.out)), s, false); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, err := csv.NewReader(&b).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+
+	assertLine(t, []string{"Key", "Items"}, lines[0])
+	assertLine(t, []string{"test1", "[1,2,3]"}, lines[1])
+	assertLine(t, []string{"test2", "[4,5,6]"}, lines[2])
+}
+
 func Test_writeTo_slice_structs(t *testing.T) {
 	b := bytes.Buffer{}
 	e := &encoder{out: &b}

--- a/types.go
+++ b/types.go
@@ -332,7 +332,9 @@ func getFieldAsString(field reflect.Value) (str string, err error) {
 			}
 		default:
 			// Not a native type, check for marshal method
+			fmt.Printf("Calling marshal, Type: %s, CanInterface: %t\n", field.Kind(), field.CanInterface())
 			str, err = marshall(field)
+			fmt.Printf("After marshal: %s\n", str)
 			if err != nil {
 				if _, ok := err.(NoMarshalFuncError); !ok {
 					return str, err
@@ -366,6 +368,15 @@ func getFieldAsString(field reflect.Value) (str string, err error) {
 					if err != nil {
 						return str, err
 					}
+				case reflect.Slice:
+					fallthrough
+				case reflect.Array:
+					b, err := json.Marshal(field.Addr().Interface())
+					if err != nil {
+						return str, err
+					}
+
+					str = string(b)
 				}
 			} else {
 				return str, nil

--- a/unmarshaller_test.go
+++ b/unmarshaller_test.go
@@ -73,7 +73,7 @@ func TestUnmarshalListOfStructsAfterMarshal(t *testing.T) {
 		t.Fatalf("Error marshalling data to CSV: %#v", err)
 	}
 
-	if string(buffer.Bytes()) != "Additional|Key\n|test\n" {
+	if string(buffer.Bytes()) != "Additional|Key\nnull|test\n" {
 		t.Fatalf("Marshalled data had an unexpected form of %s", buffer.Bytes())
 	}
 


### PR DESCRIPTION
This pull request adds support for marshalling slice or array fields that are not associated with a `csv` tag.