### PR TITLE
Allow clashing field names of nested structs to be overridden with custom unmarshalers

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -268,6 +268,23 @@ bar`)
 	}
 }
 
+func Test_readTo_embed_unmarshal_csv_with_clashing_field(t *testing.T) {
+	b := bytes.NewBufferString(`Symbol,Timestamp
+test,1656460798.693201614`)
+	d := newSimpleDecoderFromReader(b)
+	var rows []EmbedUnmarshalCSVWithClashingField
+	if err := readTo(d, &rows); err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := EmbedUnmarshalCSVWithClashingField{
+		Symbol:    "test",
+		Timestamp: &UnmarshalCSVSample{Timestamp: 1656460798, Nanos: 693201614},
+	}
+	if !reflect.DeepEqual(expected, rows[0]) {
+		t.Fatalf("expected first sample %v, got %+v", expected, rows[0])
+	}
+}
+
 func Test_readEach(t *testing.T) {
 	b := bytes.NewBufferString(`first,foo,BAR,Baz,last,abc
 aa,bb,11,cc,dd,ee

--- a/encode_test.go
+++ b/encode_test.go
@@ -331,7 +331,7 @@ func Test_writeTo_embedmarshalCSV(t *testing.T) {
 	}
 
 	assertLine(t, []string{"symbol", "timestamp"}, lines[0])
-	assertLine(t, []string{"test", "1656460798693201614"}, lines[1])
+	assertLine(t, []string{"test", "1656460798.693201614"}, lines[1])
 }
 
 func Test_writeTo_complex_embed(t *testing.T) {

--- a/reflect.go
+++ b/reflect.go
@@ -69,7 +69,7 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 		indexChain := append(cpy, i)
 		// if the field is a pointer to a struct, follow the pointer then create fieldinfo for each field
 		if field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct {
-			// unless it implements marshalText or marshalCSV. Structs that implement this
+			// Structs that implement any of the text or CSV marshaling methods
 			// should result in one value and not have their fields exposed
 			if !(canMarshal(field.Type.Elem()) || canMarshal(field.Type)) {
 				fieldsList = append(fieldsList, getFieldInfos(field.Type.Elem(), indexChain)...)
@@ -77,7 +77,7 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int) []fieldInfo {
 		}
 		// if the field is a struct, create a fieldInfo for each of its fields
 		if field.Type.Kind() == reflect.Struct {
-			// unless it implements marshalText or marshalCSV. Structs that implement this
+			// Structs that implement any of the text or CSV marshaling methods
 			// should result in one value and not have their fields exposed
 			if !(canMarshal(field.Type)) {
 				fieldsList = append(fieldsList, getFieldInfos(field.Type, indexChain)...)

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -64,7 +64,7 @@ func (timestamp *MarshalCSVSample) MarshalCSV() (string, error) {
 		return "", nil
 	}
 
-	return fmt.Sprintf("%d%09d", timestamp.Seconds, timestamp.Nanos), nil
+	return fmt.Sprintf("%d.%09d", timestamp.Seconds, timestamp.Nanos), nil
 }
 
 type EmbedMarshalCSV struct {

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -72,6 +72,27 @@ type EmbedMarshalCSV struct {
 	Timestamp *MarshalCSVSample `csv:"timestamp"`
 }
 
+type UnmarshalCSVSample struct {
+	Timestamp int64
+	Nanos     int32
+}
+
+func (timestamp *UnmarshalCSVSample) UnmarshalCSV(s string) error {
+	ret := UnmarshalCSVSample{}
+	_, err := fmt.Sscanf(s, "%d.%09d", &ret.Timestamp, &ret.Nanos)
+	*timestamp = ret
+	return err
+}
+
+type EmbedUnmarshalCSVWithClashingField struct {
+	Symbol string
+
+	// Clashes on purpose with UnmarshalCSVSample's Timestamp field. Since
+	// *UnmarshalCSVSample implements UnmarshalCSV(), that method call should
+	// take precedence.
+	Timestamp *UnmarshalCSVSample
+}
+
 type EmbedPtrSample struct {
 	Qux string `csv:"first"`
 	*Sample

--- a/types.go
+++ b/types.go
@@ -388,11 +388,13 @@ func getFieldAsString(field reflect.Value) (str string, err error) {
 // Un/serializations helpers
 
 func canMarshal(t reflect.Type) bool {
-	// unless it implements marshalText or marshalCSV. Structs that implement this
+	// Structs that implement any of the text or CSV marshaling methods
 	// should result in one value and not have their fields exposed
 	_, canMarshalText := t.MethodByName("MarshalText")
 	_, canMarshalCSV := t.MethodByName("MarshalCSV")
-	return canMarshalCSV || canMarshalText
+	_, canUnmarshalText := t.MethodByName("UnmarshalText")
+	_, canUnmarshalCSV := t.MethodByName("UnmarshalCSV")
+	return canMarshalCSV || canMarshalText || canUnmarshalText || canUnmarshalCSV
 }
 
 func unmarshall(field reflect.Value, value string) error {


### PR DESCRIPTION
This comes down to not exposing the field names of nested structs as a `fieldInfo` if the struct implements `UnmarshalText` or `UnmarshalCSV`. https://github.com/gocarina/gocsv/commit/eeb477f6ec9dd44065df8d0960bc9ef37f4153ea already prevented the same if the struct implements `MarshalCSV` or `MarshalText`, but I would say that this should also be the case if just
 one or both of the *unmarshaling* methods are defined.

Otherwise, an exported field from a nested structure will shadow the intended unmarshaling behavior of the top-level structure if one of its fields has the same name as a field of the nested structure itself. See the added test for an example.

Changing this doesn't break any of the existing tests.