### PR TITLE
Fixes example code for specified delimiter in writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ func main() {
 
         ...
 
-        gocsv.SetCSVWriter(func(out io.Writer) *SafeCSVWriter {
+        gocsv.SetCSVWriter(func(out io.Writer) *gocsv.SafeCSVWriter {
             writer := csv.NewWriter(out)
             writer.Comma = '|'
             return gocsv.NewSafeCSVWriter(writer)


### PR DESCRIPTION
Adds package name to type.
Now it works by copy-and-paste.