### PR TITLE
Respect csv ignore tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,16 @@ import (
 	"github.com/gocarina/gocsv"
 )
 
+type NotUsed struct {
+	Name string
+}
+
 type Client struct { // Our example struct, you can use "-" to ignore a field
-	Id      string `csv:"client_id"`
-	Name    string `csv:"client_name"`
-	Age     string `csv:"client_age"`
-	NotUsed string `csv:"-"`
+	Id            string `csv:"client_id"`
+	Name          string `csv:"client_name"`
+	Age           string `csv:"client_age"`
+	NotUsedString string `csv:"-"`
+	NotUsedStruct NotUsed `csv:"-"` 
 }
 
 func main() {

--- a/custom_unmarshaller_test.go
+++ b/custom_unmarshaller_test.go
@@ -48,18 +48,29 @@ func Test_CSV_Base(t *testing.T) {
 type FieldWithCustomMarshaller struct {
 	value string
 }
-type TestStruct struct {
-	OkValue                   string
-	FieldWithCustomMarshaller FieldWithCustomMarshaller
-}
 
 func (f *FieldWithCustomMarshaller) UnmarshalCSV(csv string) (err error) {
 	f.value = csv
 	return err
 }
 
+type FieldWithCustomMarshallerPointed struct {
+	otherValue string
+}
+
+func (f *FieldWithCustomMarshallerPointed) UnmarshalCSV(csv string) (err error) {
+	f.otherValue = csv
+	return err
+}
+
+type TestStruct struct {
+	OkValue                          string
+	FieldWithCustomMarshaller        FieldWithCustomMarshaller
+	FieldWithCustomMarshallerPointed *FieldWithCustomMarshallerPointed
+}
+
 func TestPanic(t *testing.T) {
-	line := "hello,world"
+	line := "make,backups,test it"
 	r := strings.NewReader(line)
 	var DataValues []TestStruct
 	err := UnmarshalWithoutHeaders(r, &DataValues)

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -136,11 +136,11 @@ type DateTime struct {
 }
 
 type Level0Struct struct {
-	Level0Field level1Struct `csv:"-"`
+	Level0Field level1Struct
 }
 
 type level1Struct struct {
-	Level1Field level2Struct `csv:"-"`
+	Level1Field level2Struct
 }
 
 type level2Struct struct {


### PR DESCRIPTION
We auto-create structs using https://github.com/volatiletech/sqlboiler.  
And load in data using e.g. csv via gocsv.

For sqlboiler to work, they have `R` and `L` fields. Those fields are other structs (or pointer to them). And the relation can circle.

This results for some structs in infinity loops.

Respecting the csv ignore `"-"` would resolve this.  
This PR aims to do that.  
After running our code we get no more infinity loops.

example output struct
```
type Pilot struct {
  ID   int    `boil:"id" json:"id" toml:"id" yaml:"id"`
  Name string `boil:"name" json:"name" toml:"name" yaml:"name"`

  R *pilotR `boil:"-" json:"-" toml:"-" yaml:"-"`
  L pilotR  `boil:"-" json:"-" toml:"-" yaml:"-"`
}
```

Probably fixes #168