### PR TITLE
Unrevert "Prefix fields of nested struct with tag of nested struct + ."

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1019,3 +1019,39 @@ func BenchmarkUnmarshalCSVToMap(b *testing.B) {
 		}
 	}
 }
+
+func Test_readTo_nested_struct(t *testing.T) {
+	b := bytes.NewBufferString(`one.boolField1,one.stringField2,two.boolField1,two.stringField2,three.boolField1,three.stringField2
+false,email_one,true,email_two,false,email_three`)
+	d := newSimpleDecoderFromReader(b)
+
+	var samples []NestedSample
+	err := readTo(d, &samples)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	expected := []NestedSample{
+		{
+			Inner1: InnerStruct{
+				BoolIgnoreField0: false,
+				BoolField1:       false,
+				StringField2:     "email_one",
+			},
+			Inner2: InnerStruct{
+				BoolIgnoreField0: false,
+				BoolField1:       true,
+				StringField2:     "email_two",
+			},
+			Inner3: NestedEmbedSample{InnerStruct{
+				BoolIgnoreField0: false,
+				BoolField1:       false,
+				StringField2:     "email_three",
+			}},
+		},
+	}
+
+	if !reflect.DeepEqual(expected, samples) {
+		t.Fatalf("expected \n  sample: %v\n     got: %v", expected, samples)
+	}
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -534,3 +534,45 @@ func Benchmark_MarshalCSVWithoutHeaders(b *testing.B) {
 		}
 	}
 }
+
+func Test_writeTo_nested_struct(t *testing.T) {
+	b := bytes.Buffer{}
+	e := &encoder{out: &b}
+	s := []NestedSample{
+		{
+			Inner1: InnerStruct{
+				BoolIgnoreField0: false,
+				BoolField1:       false,
+				StringField2:     "email_one",
+			},
+			Inner2: InnerStruct{
+				BoolIgnoreField0: true,
+				BoolField1:       true,
+				StringField2:     "email_two",
+			},
+			InnerIgnore: InnerStruct{
+				BoolIgnoreField0: true,
+				BoolField1:       false,
+				StringField2:     "email_ignore",
+			},
+			Inner3: NestedEmbedSample{InnerStruct{
+				BoolIgnoreField0: true,
+				BoolField1:       false,
+				StringField2:     "email_three",
+			}},
+		},
+	}
+	if err := writeTo(NewSafeCSVWriter(csv.NewWriter(e.out)), s, false); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, err := csv.NewReader(&b).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	assertLine(t, []string{"one.boolField1", "one.stringField2", "two.boolField1", "two.stringField2", "three.boolField1", "three.stringField2"}, lines[0])
+	assertLine(t, []string{"false", "email_one", "true", "email_two", "false", "email_three"}, lines[1])
+}

--- a/examples/full/.gitignore
+++ b/examples/full/.gitignore
@@ -1,0 +1,1 @@
+clients.csv

--- a/examples/full/main.go
+++ b/examples/full/main.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/gocarina/gocsv"
+)
+
+type NotUsed struct {
+	Name string
+}
+
+type Client struct { // Our example struct, you can use "-" to ignore a field
+	ID            string   `csv:"client_id"`
+	Name          string   `csv:"client_name"`
+	Age           string   `csv:"client_age"`
+	NotUsedString string   `csv:"-"`
+	NotUsedStruct NotUsed  `csv:"-"`
+	Address1      Address  `csv:"addr1"`
+	Address2      Address  //`csv:"addr2"` will use Address2 in header
+	Employed      DateTime `csv:"employed"`
+}
+
+type Address struct {
+	Street string `csv:"street"`
+	City   string `csv:"city"`
+}
+
+var _ gocsv.TypeMarshaller = new(DateTime)
+var _ gocsv.TypeUnmarshaller = new(DateTime)
+
+type DateTime struct {
+	time.Time
+}
+
+// Convert the internal date as CSV string
+func (date *DateTime) MarshalCSV() (string, error) {
+	return date.String(), nil
+}
+
+// You could also use the standard Stringer interface
+func (date DateTime) String() string {
+	return date.Time.Format("20060201")
+}
+
+// Convert the CSV string as internal date
+func (date *DateTime) UnmarshalCSV(csv string) (err error) {
+	date.Time, err = time.Parse("20060201", csv)
+	return err
+}
+
+func main() {
+	// set the pipe as the delimiter for writing
+	gocsv.TagSeparator = "|"
+	// set the pipe as the delimiter for reading
+	gocsv.SetCSVReader(func(in io.Reader) gocsv.CSVReader {
+		r := csv.NewReader(in)
+		r.Comma = '|'
+		return r
+	})
+
+	// Create an empty clients file
+	clientsFile, err := os.OpenFile("clients.csv", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+	if err != nil {
+		panic(err)
+	}
+	defer clientsFile.Close()
+
+	// Create clients
+	clients := []*Client{
+		{ID: "12", Name: "John", Age: "21",
+			Address1: Address{"Street 1", "City1"},
+			Address2: Address{"Street 2", "City2"},
+			Employed: DateTime{time.Date(2022, 11, 04, 12, 0, 0, 0, time.UTC)},
+		},
+		{ID: "13", Name: "Fred",
+			Address1: Address{`Main "Street" 1`, "City1"}, // show quotes in value
+			Address2: Address{"Main Street 2", "City2"},
+			Employed: DateTime{time.Date(2022, 11, 04, 13, 0, 0, 0, time.UTC)},
+		},
+		{ID: "14", Name: "James", Age: "32",
+			Address1: Address{"Center Street 1", "City1"},
+			Address2: Address{"Center Street 2", "City2"},
+			Employed: DateTime{time.Date(2022, 11, 04, 14, 0, 0, 0, time.UTC)},
+		},
+		{ID: "15", Name: "Danny",
+			Address1: Address{"State Street 1", "City1"},
+			Address2: Address{"State Street 2", "City2"},
+			Employed: DateTime{time.Date(2022, 11, 04, 15, 0, 0, 0, time.UTC)},
+		},
+	}
+	// Save clients to csv file
+	if err = gocsv.MarshalFile(&clients, clientsFile); err != nil {
+		panic(err)
+	}
+
+	// Reset the file reader
+	if _, err := clientsFile.Seek(0, io.SeekStart); err != nil {
+		panic(err)
+	}
+	// Read file and print to console
+	b, err := ioutil.ReadAll(clientsFile)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("clients.csv:")
+	fmt.Println(string(b))
+
+	// Reset the file reader
+	if _, err := clientsFile.Seek(0, io.SeekStart); err != nil {
+		panic(err)
+	}
+	// Load clients from file
+	var newClients []*Client
+	if err := gocsv.UnmarshalFile(clientsFile, &newClients); err != nil {
+		panic(err)
+	}
+	fmt.Println("clients:")
+	for _, c := range newClients {
+		fmt.Printf("%s:%s Adress1:%s, %s Address2:%s, %s Employed: %s\n",
+			c.ID, c.Name,
+			c.Address1.Street, c.Address1.City,
+			c.Address2.Street, c.Address2.City,
+			c.Employed,
+		)
+	}
+}

--- a/examples/full/main_test.go
+++ b/examples/full/main_test.go
@@ -1,0 +1,18 @@
+package main
+
+func Example() {
+	main()
+	// Output:
+	// clients.csv:
+	// client_id|client_name|client_age|addr1.street|addr1.city|Address2.street|Address2.city|employed
+	// 12|John|21|Street 1|City1|Street 2|City2|20220411
+	// 13|Fred||"Main ""Street"" 1"|City1|Main Street 2|City2|20220411
+	// 14|James|32|Center Street 1|City1|Center Street 2|City2|20220411
+	// 15|Danny||State Street 1|City1|State Street 2|City2|20220411
+	//
+	// clients:
+	// 12:John Adress1:Street 1, City1 Address2:Street 2, City2 Employed: 20220411
+	// 13:Fred Adress1:Main "Street" 1, City1 Address2:Main Street 2, City2 Employed: 20220411
+	// 14:James Adress1:Center Street 1, City1 Address2:Center Street 2, City2 Employed: 20220411
+	// 15:Danny Adress1:State Street 1, City1 Address2:State Street 2, City2 Employed: 20220411
+}

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -161,3 +161,13 @@ type UnmarshalCSVWithFieldsSample struct {
 	Baz  string  `csv:"baz"`
 	Frop float64 `csv:"frop"`
 }
+
+type NestedSample struct {
+	Inner1      InnerStruct       `csv:"one"`
+	Inner2      InnerStruct       `csv:"two"`
+	InnerIgnore InnerStruct       `csv:"-"`
+	Inner3      NestedEmbedSample `csv:"three"`
+}
+type NestedEmbedSample struct {
+	InnerStruct
+}


### PR DESCRIPTION
This undoes the breaking changes knowingly caused in #210 and also fixes the minor custom unmarshaller issue that it mentions.