### PR TITLE
feat: use CSVWriter interface instead of csv.Writer in SafeCSVWriter

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -63,15 +63,15 @@ var selfCSVWriter = DefaultCSVWriter
 
 // DefaultCSVWriter is the default SafeCSVWriter used to format CSV (cf. csv.NewWriter)
 func DefaultCSVWriter(out io.Writer) *SafeCSVWriter {
-	writer := NewSafeCSVWriter(csv.NewWriter(out))
+	originalWriter := csv.NewWriter(out)
 
 	// As only one rune can be defined as a CSV separator, we are going to trim
 	// the custom tag separator and use the first rune.
 	if runes := []rune(strings.TrimSpace(TagSeparator)); len(runes) > 0 {
-		writer.Comma = runes[0]
+		originalWriter.Comma = runes[0]
 	}
 
-	return writer
+	return NewSafeCSVWriter(originalWriter)
 }
 
 // SetCSVWriter sets the SafeCSVWriter used to format CSV.

--- a/encode_test.go
+++ b/encode_test.go
@@ -461,9 +461,9 @@ func TestRenamedTypesMarshal(t *testing.T) {
 	}
 
 	SetCSVWriter(func(out io.Writer) *SafeCSVWriter {
-		csvout := NewSafeCSVWriter(csv.NewWriter(out))
-		csvout.Comma = ';'
-		return csvout
+		writer := csv.NewWriter(out)
+		writer.Comma = ';'
+		return NewSafeCSVWriter(writer)
 	})
 	// Switch back to default for tests executed after this
 	defer SetCSVWriter(DefaultCSVWriter)

--- a/safe_csv.go
+++ b/safe_csv.go
@@ -2,7 +2,6 @@ package gocsv
 
 //Wraps around SafeCSVWriter and makes it thread safe.
 import (
-	"encoding/csv"
 	"sync"
 )
 
@@ -13,13 +12,13 @@ type CSVWriter interface {
 }
 
 type SafeCSVWriter struct {
-	*csv.Writer
+	CSVWriter
 	m sync.Mutex
 }
 
-func NewSafeCSVWriter(original *csv.Writer) *SafeCSVWriter {
+func NewSafeCSVWriter(original CSVWriter) *SafeCSVWriter {
 	return &SafeCSVWriter{
-		Writer: original,
+		CSVWriter: original,
 	}
 }
 
@@ -27,12 +26,12 @@ func NewSafeCSVWriter(original *csv.Writer) *SafeCSVWriter {
 func (w *SafeCSVWriter) Write(row []string) error {
 	w.m.Lock()
 	defer w.m.Unlock()
-	return w.Writer.Write(row)
+	return w.CSVWriter.Write(row)
 }
 
 //Override flush
 func (w *SafeCSVWriter) Flush() {
 	w.m.Lock()
-	w.Writer.Flush()
+	w.CSVWriter.Flush()
 	w.m.Unlock()
 }


### PR DESCRIPTION
Using the interface instead of the `encoding/csv.Writer` allows users to use truly custom writers, or to add their own wrappers in the writer chain.

We have a use case where we want to transform our fields before writing, and allowing us to wrap the writer while keeping the lib provided SafeCSVWriter would be quite cool!

This is a breaking change as it changes the contract of `type SafeCSVWriter` (props from the `csv.Writer` can no longer be accessed from it), but I think it would be better to decouple these two?    
Let me know if you think there is any downside to this? I don't see any but I am quite new with Go