### PR TITLE
Fix nested non marshaling structs prefixing

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -587,9 +587,10 @@ func Test_non_marshaling_nested_fields_are_prefixed(t *testing.T) {
 	s := []SameNameStruct{
 		SameNameStruct{
 			Inner2: &InnerStruct2{
-				Inner3: InnerStruct3{Foo: time1},
+				Bar:    "bar1",
+				Inner3: InnerStruct3{Bar: "bar2", Foo: time1},
 			},
-			Inner3: InnerStruct3{Foo: time2},
+			Inner3: InnerStruct3{Bar: "bar3", Foo: time2},
 			Foo:    time3,
 		},
 	}
@@ -603,6 +604,7 @@ func Test_non_marshaling_nested_fields_are_prefixed(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(lines))
 	}
-	assertLine(t, []string{"Inner2.Inner3.Foo", "Inner3.Foo", "Foo"}, lines[0])
-	assertLine(t, []string{"2021-02-19T00:00:00Z", "2022-02-19T00:00:00Z", "2023-02-19T00:00:00Z"}, lines[1])
+	// The headers should contain the struct path prefixes even if struct is responsible for its marshalling like time.Time
+	assertLine(t, []string{"Inner2.Bar", "Inner2.Inner3.Bar", "Inner2.Inner3.Foo", "Inner3.Bar", "Inner3.Foo", "Foo"}, lines[0])
+	assertLine(t, []string{"bar1", "bar2", "2021-02-19T00:00:00Z", "bar3", "2022-02-19T00:00:00Z", "2023-02-19T00:00:00Z"}, lines[1])
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -576,3 +576,33 @@ func Test_writeTo_nested_struct(t *testing.T) {
 	assertLine(t, []string{"one.boolField1", "one.stringField2", "two.boolField1", "two.stringField2", "three.boolField1", "three.stringField2"}, lines[0])
 	assertLine(t, []string{"false", "email_one", "true", "email_two", "false", "email_three"}, lines[1])
 }
+
+func Test_non_marshaling_nested_fields_are_prefixed(t *testing.T) {
+	b := bytes.Buffer{}
+	e := &encoder{out: &b}
+	time1 := time.Date(2021, 2, 19, 0, 0, 0, 0, time.UTC)
+	time2 := time.Date(2022, 2, 19, 0, 0, 0, 0, time.UTC)
+	time3 := time.Date(2023, 2, 19, 0, 0, 0, 0, time.UTC)
+
+	s := []SameNameStruct{
+		SameNameStruct{
+			Inner2: &InnerStruct2{
+				Inner3: InnerStruct3{Foo: time1},
+			},
+			Inner3: InnerStruct3{Foo: time2},
+			Foo:    time3,
+		},
+	}
+	if err := writeTo(NewSafeCSVWriter(csv.NewWriter(e.out)), s, false); err != nil {
+		t.Fatal(err)
+	}
+	lines, err := csv.NewReader(&b).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	assertLine(t, []string{"Inner2.Inner3.Foo", "Inner3.Foo", "Foo"}, lines[0])
+	assertLine(t, []string{"2021-02-19T00:00:00Z", "2022-02-19T00:00:00Z", "2023-02-19T00:00:00Z"}, lines[1])
+}

--- a/reflect.go
+++ b/reflect.go
@@ -23,7 +23,7 @@ type fieldInfo struct {
 	omitEmpty    bool
 	IndexChain   []int
 	defaultValue string
-	partial	     bool
+	partial      bool
 }
 
 func (f fieldInfo) getFirstKey() string {
@@ -83,16 +83,25 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int, parentKeys []stri
 				currFieldInfo.keys = []string{normalizeName(field.Name)}
 			}
 
-			if len(parentKeys) > 0 && currFieldInfo != nil && !canMarshal(field.Type) {
-				// create cartesian product of keys
-				// eg: parent keys x field keys
-				keys := make([]string, 0, len(parentKeys)*len(currFieldInfo.keys))
-				for _, pkey := range parentKeys {
-					for _, ckey := range currFieldInfo.keys {
-						keys = append(keys, normalizeName(fmt.Sprintf("%s.%s", pkey, ckey)))
+			if len(parentKeys) > 0 && currFieldInfo != nil {
+
+				if !canMarshal(field.Type) {
+					// create cartesian product of keys
+					// eg: parent keys x field keys
+					keys := make([]string, 0, len(parentKeys)*len(currFieldInfo.keys))
+					for _, pkey := range parentKeys {
+						for _, ckey := range currFieldInfo.keys {
+							keys = append(keys, normalizeName(fmt.Sprintf("%s.%s", pkey, ckey)))
+						}
+						currFieldInfo.keys = keys
+					}
+				} else {
+					keys := make([]string, 0, len(parentKeys))
+					for _, pkey := range parentKeys {
+						keys = append(keys, normalizeName(fmt.Sprintf("%s.%s", pkey, normalizeName(field.Name))))
+						currFieldInfo.keys = keys
 					}
 				}
-				currFieldInfo.keys = keys
 			}
 		}
 

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -153,6 +153,20 @@ type InnerStruct struct {
 	StringField2     string `csv:"stringField2"`
 }
 
+type InnerStruct3 struct {
+	Foo time.Time
+}
+
+type InnerStruct2 struct {
+	Inner3 InnerStruct3
+}
+
+type SameNameStruct struct {
+	Inner2 *InnerStruct2
+	Inner3 InnerStruct3
+	Foo    time.Time
+}
+
 var _ TypeUnmarshalCSVWithFields = (*UnmarshalCSVWithFieldsSample)(nil)
 
 type UnmarshalCSVWithFieldsSample struct {

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -154,10 +154,12 @@ type InnerStruct struct {
 }
 
 type InnerStruct3 struct {
+	Bar string
 	Foo time.Time
 }
 
 type InnerStruct2 struct {
+	Bar    string
 	Inner3 InnerStruct3
 }
 


### PR DESCRIPTION
Hi,

I ran into a problem when a struct contained a CreatedAt field and one of its substruct (eg. Inner) also contained a name with the same field name. The type of both fields were time.Time.  When exported to CSV the column name of Inner was not prefixed with "Inner", so in the resulting header field list CreatedAt occured two times. 

I expected CreatedAt and Inner.CreatedAt as column names instead of CreatedAt, CreatedAt.

After some debugging I hope I was able to find the root cause and provide a fix for it. I created a test case too.

Thx, 
joe