### PR TITLE
feat: add flexibility for field-combiner rune

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -35,6 +35,9 @@ var TagName = "csv"
 // TagSeparator defines seperator string for multiple csv tags in struct fields
 var TagSeparator = ","
 
+// FieldSeperator defines how to combine parent struct with child struct
+var FieldsCombiner = "."
+
 // Normalizer is a function that takes and returns a string. It is applied to
 // struct and header field values before they are compared. It can be used to alter
 // names for comparison. For instance, you could allow case insensitive matching

--- a/reflect.go
+++ b/reflect.go
@@ -91,14 +91,14 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int, parentKeys []stri
 					keys := make([]string, 0, len(parentKeys)*len(currFieldInfo.keys))
 					for _, pkey := range parentKeys {
 						for _, ckey := range currFieldInfo.keys {
-							keys = append(keys, normalizeName(fmt.Sprintf("%s.%s", pkey, ckey)))
+							keys = append(keys, normalizeName(fmt.Sprintf("%s%s%s", pkey, FieldsCombiner, ckey)))
 						}
 						currFieldInfo.keys = keys
 					}
 				} else {
 					keys := make([]string, 0, len(parentKeys))
 					for _, pkey := range parentKeys {
-						keys = append(keys, normalizeName(fmt.Sprintf("%s.%s", pkey, normalizeName(field.Name))))
+						keys = append(keys, normalizeName(fmt.Sprintf("%s%s%s", pkey, FieldsCombiner, normalizeName(field.Name))))
 						currFieldInfo.keys = keys
 					}
 				}


### PR DESCRIPTION
## Context
As explained on #240, it seems that the library doesn't have a feature to let devs control how the Parent.Child field tag is written.

## What's done
1. Added an exported `FieldsCombiner`: allows for more flexibility/control on how parent & child struct will be combined.

Would love to hear your thoughts/feedback! :)