### PR TITLE
Remove zero-width chars from key, before matches

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -32,11 +32,28 @@ func (f fieldInfo) getFirstKey() string {
 
 func (f fieldInfo) matchesKey(key string) bool {
 	for _, k := range f.keys {
-		if key == k || strings.TrimSpace(key) == k || (f.partial && strings.Contains(key, k)) {
+		if key == k || strings.TrimSpace(key) == k || (f.partial && strings.Contains(key, k)) || removeZeroWidthChars(key) == k {
 			return true
 		}
 	}
 	return false
+}
+
+// zwchs is Zero Width Characters map
+var zwchs = map[rune]struct{}{
+	'\u200B': {}, // zero width space (U+200B)
+	'\uFEFF': {}, // zero width no-break space (U+FEFF)
+	'\u200D': {}, // zero width joiner (U+200D)
+	'\u200C': {}, // zero width non-joiner (U+200C)
+}
+
+func removeZeroWidthChars(s string) string {
+	return strings.Map(func(r rune) rune {
+		if _, ok := zwchs[r]; ok {
+			return -1
+		}
+		return r
+	}, s)
 }
 
 var structInfoCache sync.Map

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -1,0 +1,93 @@
+package gocsv
+
+import "testing"
+
+func Test_fieldInfo_matchesKey(t *testing.T) {
+	type fields struct {
+		keys         []string
+		omitEmpty    bool
+		IndexChain   []int
+		defaultValue string
+		partial      bool
+	}
+	type args struct {
+		key string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "valid value",
+			fields: fields{
+				keys: []string{"date"},
+			},
+			args: args{"date"},
+			want: true,
+		},
+		{
+			name: "zero width space (U+200B)",
+			fields: fields{
+				keys: []string{"date"},
+			},
+			args: args{"\u200Bdate"},
+			want: true,
+		},
+		{
+			name: "zero width non-joiner (U+200C)",
+			fields: fields{
+				keys: []string{"date"},
+			},
+			args: args{"\u200Cdate"},
+			want: true,
+		},
+		{
+			name: "zero width joiner (U+200D)",
+			fields: fields{
+				keys: []string{"date"},
+			},
+			args: args{"\u200Ddate"},
+			want: true,
+		},
+		{
+			name: "zero width no-break space (U+FEFF)",
+			fields: fields{
+				keys: []string{"date"},
+			},
+			args: args{"\uFEFFdate"},
+			want: true,
+		},
+		{
+			name: "zero width no-break space (U+FEFF) in the middle of the string",
+			fields: fields{
+				keys: []string{"date"},
+			},
+			args: args{"da\uFEFFte"},
+			want: true,
+		},
+		{
+			name: "zero width no-break space (U+FEFF) in the end of the string",
+			fields: fields{
+				keys: []string{"date"},
+			},
+			args: args{"date\uFEFF"},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := fieldInfo{
+				keys:         tt.fields.keys,
+				omitEmpty:    tt.fields.omitEmpty,
+				IndexChain:   tt.fields.IndexChain,
+				defaultValue: tt.fields.defaultValue,
+				partial:      tt.fields.partial,
+			}
+			if got := f.matchesKey(tt.args.key); got != tt.want {
+				t.Errorf("matchesKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As a last way to compare keys, remove all zero-width characters from the key.

Solved #242 