### PR TITLE
fix: handle slice/array of Struct when csv[] tag missing

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -174,6 +174,11 @@ func Test_writeTo_slice_structs(t *testing.T) {
 				{String: "s2", Float: 2.2},
 				{String: "nope", Float: 3.3},
 			},
+			Slice2: []SliceStruct{
+				{String: "s1", Float: 1.1},
+				{String: "s2", Float: 2.2},
+				{String: "nope", Float: 3.3},
+			},
 			SimpleSlice: []int{1, 2, 3, 4, 5},
 			Array: [2]SliceStruct{
 				{String: "s3", Float: 3.3},
@@ -192,8 +197,8 @@ func Test_writeTo_slice_structs(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(lines))
 	}
-	assertLine(t, []string{"s[0].s", "s[0].f", "s[1].s", "s[1].f", "ints[0]", "ints[1]", "ints[2]", "a[0].s", "a[0].f", "a[1].s", "a[1].f"}, lines[0])
-	assertLine(t, []string{"s1", "1.1", "s2", "2.2", "1", "2", "3", "s3", "3.3", "s4", "4.4"}, lines[1])
+	assertLine(t, []string{"s[0].s", "s[0].f", "s[1].s", "s[1].f", "sliceText", "ints[0]", "ints[1]", "ints[2]", "a[0].s", "a[0].f", "a[1].s", "a[1].f"}, lines[0])
+	assertLine(t, []string{"s1", "1.1", "s2", "2.2", "[{\"String\":\"s1\",\"Float\":1.1},{\"String\":\"s2\",\"Float\":2.2},{\"String\":\"nope\",\"Float\":3.3}]", "1", "2", "3", "s3", "3.3", "s4", "4.4"}, lines[1])
 }
 
 func Test_writeTo_embed(t *testing.T) {

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -21,6 +21,7 @@ type SliceSample struct {
 
 type SliceStructSample struct {
 	Slice       []SliceStruct  `csv:"s,slice" csv[]:"2"`
+	Slice2      []SliceStruct  `csv:"sliceText"`
 	SimpleSlice []int          `csv:"ints" csv[]:"3"`
 	Array       [2]SliceStruct `csv:"a,array" csv[]:"2"`
 }


### PR DESCRIPTION
For a field that is simply a slice or an array of a Struct, if no special `csv[]` tag is supplied, just marshal the array elements to string, encoded into the csv column.

This won't interfere with the csv[] field expansion logic.
