### PR TITLE
UnmarshalToCallback functions don't return reader's error

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -354,7 +354,7 @@ func UnmarshalToCallback(in io.Reader, f interface{}) error {
 			}
 		}
 	}
-	return nil
+	return <-cerr
 }
 
 // UnmarshalDecoderToCallback parses the CSV from the decoder and send each value to the given func f.
@@ -382,7 +382,8 @@ func UnmarshalDecoderToCallback(in SimpleDecoder, f interface{}) error {
 		}
 		valueFunc.Call([]reflect.Value{v})
 	}
-	return nil
+
+	return <-cerr
 }
 
 // UnmarshalBytesToCallback parses the CSV from the bytes and send each value to the given func f.

--- a/csv.go
+++ b/csv.go
@@ -382,7 +382,6 @@ func UnmarshalDecoderToCallback(in SimpleDecoder, f interface{}) error {
 		}
 		valueFunc.Call([]reflect.Value{v})
 	}
-
 	return <-cerr
 }
 

--- a/csv_test.go
+++ b/csv_test.go
@@ -1,0 +1,34 @@
+package gocsv
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestUnmarshalToCallback_ReaderError(t *testing.T) {
+	type Dummy struct{}
+	var reader = &errorReader{}
+
+	err := UnmarshalToCallback(reader, func(Dummy) {})
+	if !errors.Is(err, readerErr) {
+		t.Error("UnmarshalToCallback should return first reader error")
+	}
+
+	err = UnmarshalDecoderToCallback(newSimpleDecoderFromReader(reader), func(Dummy) {})
+	if !errors.Is(err, readerErr) {
+		t.Error("UnmarshalDecoderToCallback should return first reader error")
+	}
+
+	err = UnmarshalToCallbackWithError(reader, func(Dummy) error { return nil })
+	if !errors.Is(err, readerErr) {
+		t.Error("UnmarshalToCallbackWithError should return first reader error")
+	}
+}
+
+type errorReader struct{}
+
+func (e *errorReader) Read([]byte) (n int, err error) {
+	return 0, readerErr
+}
+
+var readerErr = errors.New("reader error")


### PR DESCRIPTION
I've added a testcase for this situation. Current implementation will just ignore pending error.

It should be safe to use pure read of cerr chans in these cases. Functions reach final return statements only when c is closed. So UnmarshalToChan returned successfully and wrote to cerr.