### PR TITLE
Add generics to chan and callback-using functions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.11
+        go-version: ^1.18
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/csv_test.go
+++ b/csv_test.go
@@ -7,14 +7,14 @@ import (
 
 func TestUnmarshalToCallback_ReaderError(t *testing.T) {
 	type Dummy struct{}
-	var reader = &errorReader{}
+	reader := &errorReader{}
 
-	err := UnmarshalToCallback(reader, func(Dummy) {})
+	err := UnmarshalToCallback(reader, func(Dummy) error { return nil })
 	if !errors.Is(err, readerErr) {
 		t.Error("UnmarshalToCallback should return first reader error")
 	}
 
-	err = UnmarshalDecoderToCallback(newSimpleDecoderFromReader(reader), func(Dummy) {})
+	err = UnmarshalDecoderToCallback(newSimpleDecoderFromReader(reader), func(Dummy) error { return nil })
 	if !errors.Is(err, readerErr) {
 		t.Error("UnmarshalDecoderToCallback should return first reader error")
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -616,8 +616,9 @@ func TestUnmarshalToCallback(t *testing.T) {
 aa,bb,11,cc,dd,ee
 ff,gg,22,hh,ii,jj`)
 	var samples []SkipFieldSample
-	if err := UnmarshalBytesToCallback(b.Bytes(), func(s SkipFieldSample) {
+	if err := UnmarshalBytesToCallback(b.Bytes(), func(s SkipFieldSample) error {
 		samples = append(samples, s)
+		return nil
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1020,8 +1021,9 @@ f,1,baz,,        *string
 e,3,b,,                            `)
 
 	var samples []Sample
-	if err := UnmarshalDecoderToCallback(&trimDecoder{LazyCSVReader(b)}, func(s Sample) {
+	if err := UnmarshalDecoderToCallback(&trimDecoder{LazyCSVReader(b)}, func(s Sample) error {
 		samples = append(samples, s)
+		return nil
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/encode.go
+++ b/encode.go
@@ -7,9 +7,7 @@ import (
 	"reflect"
 )
 
-var (
-	ErrChannelIsClosed = errors.New("channel is closed")
-)
+var ErrChannelIsClosed = errors.New("channel is closed")
 
 type encoder struct {
 	out io.Writer
@@ -19,7 +17,7 @@ func newEncoder(out io.Writer) *encoder {
 	return &encoder{out}
 }
 
-func writeFromChan(writer CSVWriter, c <-chan interface{}, omitHeaders bool) error {
+func writeFromChan[T any](writer CSVWriter, c <-chan T, omitHeaders bool) error {
 	// Get the first value. It wil determine the header structure.
 	firstValue, ok := <-c
 	if !ok {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gocarina/gocsv
 
-go 1.13
+go 1.18


### PR DESCRIPTION
I use this repo a lot and having to cast interfaces is a bit annoying now that we have generics.

This is a simplistic proposal to move to generics. Note that the go.mod version has gone from 1.13 to 1.18

This addresses #271 