### PR TITLE
Support TypeUnmarshalCSVWithFields in readEach

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -203,22 +203,22 @@ func readToWithErrorHandler(decoder Decoder, errHandler ErrorHandler, out interf
 		objectIface := reflect.New(outValue.Index(i).Type()).Interface()
 		outInner := createNewOutInner(outInnerWasPointer, outInnerType)
 		for j, csvColumnContent := range csvRow {
-			if fieldInfo, ok := csvHeadersLabels[j]; ok { // Position found accordingly to header name
-
-				if outInner.CanInterface() {
-					fieldTypeUnmarshallerWithKeys, withFieldsOK = objectIface.(TypeUnmarshalCSVWithFields)
-					if withFieldsOK {
-						if err := fieldTypeUnmarshallerWithKeys.UnmarshalCSVWithFields(fieldInfo.getFirstKey(), csvColumnContent); err != nil {
-							parseError := csv.ParseError{
-								Line:   i + 2, //add 2 to account for the header & 0-indexing of arrays
-								Column: j + 1,
-								Err:    err,
-							}
-							return &parseError
+			if outInner.CanInterface() {
+				fieldTypeUnmarshallerWithKeys, withFieldsOK = objectIface.(TypeUnmarshalCSVWithFields)
+				if withFieldsOK {
+					if err := fieldTypeUnmarshallerWithKeys.UnmarshalCSVWithFields(headers[j], csvColumnContent); err != nil {
+						parseError := csv.ParseError{
+							Line:   i + 2, //add 2 to account for the header & 0-indexing of arrays
+							Column: j + 1,
+							Err:    err,
 						}
-						continue
+						return &parseError
 					}
+					continue
 				}
+			}
+
+			if fieldInfo, ok := csvHeadersLabels[j]; ok { // Position found accordingly to header name
 				value := csvColumnContent
 				if value == "" {
 					value = fieldInfo.defaultValue

--- a/decode.go
+++ b/decode.go
@@ -289,8 +289,13 @@ func readEach(decoder SimpleDecoder, errHandler ErrorHandler, c interface{}) err
 			return err
 		}
 	}
+
+	var withFieldsOK bool
+	var fieldTypeUnmarshallerWithKeys TypeUnmarshalCSVWithFields
+
 	i := 0
 	for {
+		objectIface := reflect.New(outValue.Type().Elem()).Interface()
 		line, err := decoder.GetCSVRow()
 		if err == io.EOF {
 			break
@@ -299,8 +304,31 @@ func readEach(decoder SimpleDecoder, errHandler ErrorHandler, c interface{}) err
 		}
 		outInner := createNewOutInner(outInnerWasPointer, outInnerType)
 		for j, csvColumnContent := range line {
+
+			if outInner.CanInterface() {
+				fieldTypeUnmarshallerWithKeys, withFieldsOK = objectIface.(TypeUnmarshalCSVWithFields)
+				if withFieldsOK {
+					if err := fieldTypeUnmarshallerWithKeys.UnmarshalCSVWithFields(headers[j], csvColumnContent); err != nil {
+						parseError := csv.ParseError{
+							Line:   i + 2, //add 2 to account for the header & 0-indexing of arrays
+							Column: j + 1,
+							Err:    err,
+						}
+						return &parseError
+					}
+
+					continue
+				}
+			}
+
 			if fieldInfo, ok := csvHeadersLabels[j]; ok { // Position found accordingly to header name
-				if err := setInnerField(&outInner, outInnerWasPointer, fieldInfo.IndexChain, csvColumnContent, fieldInfo.omitEmpty); err != nil { // Set field of struct
+
+				value := csvColumnContent
+				if value == "" {
+					value = fieldInfo.defaultValue
+				}
+
+				if err := setInnerField(&outInner, outInnerWasPointer, fieldInfo.IndexChain, value, fieldInfo.omitEmpty); err != nil { // Set field of struct
 					parseError := &csv.ParseError{
 						Line:   i + 2, //add 2 to account for the header & 0-indexing of arrays
 						Column: j + 1,
@@ -313,6 +341,12 @@ func readEach(decoder SimpleDecoder, errHandler ErrorHandler, c interface{}) err
 				}
 			}
 		}
+
+		if withFieldsOK {
+			reflectedObject := reflect.ValueOf(objectIface)
+			outInner = reflectedObject.Elem()
+		}
+
 		outValue.Send(outInner)
 		i++
 	}

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -188,3 +188,9 @@ type NestedSample struct {
 type NestedEmbedSample struct {
 	InnerStruct
 }
+
+type NoTagsSample struct {
+	Fields map[string]string
+}
+
+var _ TypeUnmarshalCSVWithFields = (*NoTagsSample)(nil)


### PR DESCRIPTION
- Add support for calling TypeUnmarshalCSVWithFields interface in readEach function similar to readTo
- Slight rearrangment of calling UnmarshalCSVWithFields for both readEach and readTo to place it above the fieldInfo check
  - A type should be able to completely handle unmarshalling by implementing this interface, it doesn't seem like it should depend on having csv tags matching the headers or not
  - This allows, for example, a csv record to be read into a struct with unknown headers; extra columns could be added to a map field in the struct, etc
- Also add missing default value setting in readEach