### PR TITLE
fix: skip extra CSV columns in readToWithoutHeaders to prevent panic

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -421,6 +421,9 @@ func readToWithoutHeaders(decoder Decoder, out interface{}) error {
 	for i, csvRow := range csvRows {
 		outInner := createNewOutInner(outInnerWasPointer, outInnerType)
 		for j, csvColumnContent := range csvRow {
+			if j >= len(outInnerStructInfo.Fields) {
+				break
+			}
 			fieldInfo := outInnerStructInfo.Fields[j]
 			if err := setInnerField(&outInner, outInnerWasPointer, fieldInfo.IndexChain, csvColumnContent, fieldInfo.omitEmpty); err != nil { // Set field of struct
 				return &csv.ParseError{


### PR DESCRIPTION
Fixes #280

## Problem

`readToWithoutHeaders` accesses `outInnerStructInfo.Fields[j]` without checking if `j` exceeds the number of struct fields. When a CSV row has more columns than struct fields, this causes:

```
panic: runtime error: index out of range [2] with length 2
```

## Fix

Add a bounds check to break when the column index exceeds the number of struct fields, silently ignoring extra columns:

```go
for j, csvColumnContent := range csvRow {
    if j >= len(outInnerStructInfo.Fields) {
        break
    }
    ...
}
```

All existing tests pass.