### PR TITLE
Match the "partial" tag option exactly (#274)

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -491,6 +491,34 @@ func TestRenamedTypesMarshal(t *testing.T) {
 	}
 }
 
+// TestColumnNameStartingWithPartial is a regression test for issue #274: a column name that
+// happens to start with "partial" (e.g. "partial_delivery_number") must not be mistaken for the
+// "partial" tag option. Previously the option was detected with strings.HasPrefix, so such a
+// column name was swallowed and gocsv fell back to using the Go field name instead.
+func TestColumnNameStartingWithPartial(t *testing.T) {
+	type sample struct {
+		PartialDeliveryNumber uint `csv:"partial_delivery_number"`
+	}
+
+	// Marshal: the header must be the csv tag, not the Go field name.
+	csvContent, err := MarshalString(&[]sample{{PartialDeliveryNumber: 7}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expected := "partial_delivery_number\n7\n"; csvContent != expected {
+		t.Fatalf("expected header from csv tag.\nexpected: %q\ngot:      %q", expected, csvContent)
+	}
+
+	// Unmarshal: a CSV whose header is the csv tag must populate the field.
+	var out []sample
+	if err := Unmarshal(bytes.NewBufferString("partial_delivery_number\n42\n"), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || out[0].PartialDeliveryNumber != 42 {
+		t.Fatalf("expected PartialDeliveryNumber=42, got %+v", out)
+	}
+}
+
 // TestCustomTagSeparatorMarshal tests for custom tag separator in marshalling.
 func TestCustomTagSeparatorMarshal(t *testing.T) {
 	samples := []RenamedSample{

--- a/reflect.go
+++ b/reflect.go
@@ -225,7 +225,10 @@ func filterTags(tagName string, indexChain []int, field reflect.StructField) (*f
 		trimmedFieldTagEntry := strings.TrimSpace(fieldTagEntry) // handles cases like `csv:"foo, omitempty, default=test"`
 		if trimmedFieldTagEntry == "omitempty" {
 			currFieldInfo.omitEmpty = true
-		} else if strings.HasPrefix(trimmedFieldTagEntry, "partial") {
+		} else if trimmedFieldTagEntry == "partial" {
+			// Must be an exact match: using HasPrefix here would mistake a column name that
+			// happens to start with "partial" (e.g. `csv:"partial_delivery_number"`) for the
+			// "partial" option, dropping the real column name. See issue #274.
 			currFieldInfo.partial = true
 		} else if strings.HasPrefix(trimmedFieldTagEntry, "default=") {
 			currFieldInfo.defaultValue = strings.TrimPrefix(trimmedFieldTagEntry, "default=")


### PR DESCRIPTION
## Summary

Fixes #274.

The `partial` tag option is a standalone boolean flag (introduced in #234) — like `omitempty` — that makes a field match any CSV header *containing* the column name. It was detected with `strings.HasPrefix(trimmedFieldTagEntry, "partial")`, so any **column name** that merely starts with `partial` was mistaken for the option.

For example, with:

```go
type T struct {
    PartialDeliveryNumber uint `csv:"partial_delivery_number"`
}
```

`partial_delivery_number` matched `HasPrefix(..., "partial")`, so it was consumed as the `partial` option and removed from the list of column names. With no name left, gocsv fell back to the Go field name — producing the header `PartialDeliveryNumber` on `Marshal` and failing to match the `partial_delivery_number` column on `Unmarshal`.

## Fix

Match the option exactly (`trimmedFieldTagEntry == "partial"`), consistent with how `omitempty` is matched just a couple of lines above. The real `partial` option (`csv:"name,partial"`) is unaffected.

```diff
-} else if strings.HasPrefix(trimmedFieldTagEntry, "partial") {
+} else if trimmedFieldTagEntry == "partial" {
```

## Testing

- Added `TestColumnNameStartingWithPartial`: a field tagged `csv:"partial_delivery_number"` now marshals to the `partial_delivery_number` header (not `PartialDeliveryNumber`) and unmarshals correctly. Confirmed it **fails without** this change and **passes with** it.
- `TestDecodePartialKeys` (the existing test for the real `partial` option) still passes, so the option itself is unchanged.
- Full test suite passes with `-race`.
