### PR TITLE
Fix panic marshaling an interface field holding an unaddressable value

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -164,6 +164,24 @@ func Test_writeTo_slice(t *testing.T) {
 	assertLine(t, []string{"test2", "[4,5,6]"}, lines[2])
 }
 
+func TestMarshalInterfaceSlice(t *testing.T) {
+	type sample struct {
+		Type  string
+		Value interface{}
+	}
+
+	csvContent, err := MarshalString(&[]sample{
+		{Type: "numbers", Value: []int64{1, 2, 3}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expected := "Type,Value\nnumbers,\"[1,2,3]\"\n"; csvContent != expected {
+		t.Fatalf("expected interface slice to marshal as JSON.\nexpected: %q\ngot:      %q", expected, csvContent)
+	}
+}
+
 func Test_writeTo_slice_structs(t *testing.T) {
 	b := bytes.Buffer{}
 	e := &encoder{out: &b}

--- a/types.go
+++ b/types.go
@@ -376,7 +376,11 @@ func getFieldAsString(field reflect.Value) (str string, err error) {
 				case reflect.Slice:
 					fallthrough
 				case reflect.Array:
-					b, err := json.Marshal(field.Addr().Interface())
+					value := field.Interface()
+					if field.CanAddr() {
+						value = field.Addr().Interface()
+					}
+					b, err := json.Marshal(value)
 					if err != nil {
 						return str, err
 					}


### PR DESCRIPTION
Fixes #279.

Marshalling a struct whose `interface{}` field holds a non-addressable value (for example a slice) panicked with `reflect.Value.Addr of unaddressable value`. Handle that case so the value is marshalled instead of panicking. Added a test marshalling an interface slice field.