### PR TITLE
Add special tag "." to inline nested fields without a prefix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,42 @@ type Client struct { // Our example struct with a custom type (DateTime)
 
 ```
 
+Nested structs
+---
+
+By default, the fields of nested structs are prefixed with the parent field's
+name. For example:
+
+```go
+type Foo struct {
+	B Bar
+	X int `csv:"x"`
+}
+
+type Bar struct {
+	A int `csv:"a"`
+	B int `csv:"b"`
+}
+```
+
+produces columns `B.a, B.b, x`.
+
+Use the `csv:"."` tag to inline the nested struct's fields without that prefix; for example:
+
+```go
+type Foo struct {
+	B Bar `csv:"."`
+	X int `csv:"x"`
+}
+
+type Bar struct {
+	A int `csv:"a"`
+	B int `csv:"b"`
+}
+```
+
+produces columns `a, b, x`.
+
 Customizable CSV Reader / Writer
 ---
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -1344,3 +1344,18 @@ false,email_one,true,email_two,false,email_three`)
 		t.Fatalf("expected \n  sample: %v\n     got: %v", expected, samples)
 	}
 }
+
+func Test_readTo_inline_nested_struct(t *testing.T) {
+	b := bytes.NewBufferString("a,b,x\n1,2,3")
+	d := newSimpleDecoderFromReader(b)
+
+	var samples []InlineFooSample
+	if err := readTo(d, &samples); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	expected := []InlineFooSample{{Bar: InlineBar{A: 1, B: 2}, X: 3}}
+	if !reflect.DeepEqual(expected, samples) {
+		t.Fatalf("expected \n  sample: %v\n     got: %v", expected, samples)
+	}
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -681,3 +681,48 @@ func Test_non_marshaling_nested_fields_are_prefixed(t *testing.T) {
 	assertLine(t, []string{"Inner2.Bar", "Inner2.Inner3.Bar", "Inner2.Inner3.Foo", "Inner3.Bar", "Inner3.Foo", "Foo"}, lines[0])
 	assertLine(t, []string{"bar1", "bar2", "2021-02-19T00:00:00Z", "bar3", "2022-02-19T00:00:00Z", "2023-02-19T00:00:00Z"}, lines[1])
 }
+
+func Test_writeTo_inline_nested_struct(t *testing.T) {
+	b := bytes.Buffer{}
+	e := &encoder{out: &b}
+	s := []InlineFooSample{
+		{Bar: InlineBar{A: 1, B: 2}, X: 3},
+	}
+	if err := writeTo(NewSafeCSVWriter(csv.NewWriter(e.out)), s, false); err != nil {
+		t.Fatal(err)
+	}
+	lines, err := csv.NewReader(&b).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	// The `csv:"."` tag inlines Bar's fields without the "Bar." prefix.
+	assertLine(t, []string{"a", "b", "x"}, lines[0])
+	assertLine(t, []string{"1", "2", "3"}, lines[1])
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		got, err := MarshalString([]InlineFooPtrSample{{Bar: &InlineBar{A: 4, B: 5}, X: 6}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := "a,b,x\n4,5,6\n"
+		if got != want {
+			t.Fatalf("expected:\n%s\ngot:\n%s", want, got)
+		}
+	})
+
+	t.Run("inline struct nested under a prefixed field", func(t *testing.T) {
+		got, err := MarshalString([]InlineOuterSample{{Foo: InlineFooSample{Bar: InlineBar{A: 1, B: 2}, X: 3}, Y: 4}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Foo is prefixed with "foo", and Bar's "." tag drops only its own name,
+		// so Bar's fields keep the inherited "foo." prefix.
+		want := "foo.a,foo.b,foo.x,y\n1,2,3,4\n"
+		if got != want {
+			t.Fatalf("expected:\n%s\ngot:\n%s", want, got)
+		}
+	})
+}

--- a/reflect.go
+++ b/reflect.go
@@ -24,6 +24,7 @@ type fieldInfo struct {
 	IndexChain   []int
 	defaultValue string
 	partial      bool
+	inline       bool
 }
 
 func (f fieldInfo) getFirstKey() string {
@@ -86,6 +87,15 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int, parentKeys []stri
 		copy(cpy, parentIndexChain)
 		indexChain := append(cpy, i)
 
+		// Determine whether it's a struct we can expand into nested columns.
+		// Structs that implement any of the text or CSV marshaling methods
+		// should result in one value and not have their fields exposed
+		fieldType := field.Type
+		if fieldType.Kind() == reflect.Ptr {
+			fieldType = fieldType.Elem()
+		}
+		isExpandableStruct := fieldType.Kind() == reflect.Struct && !canMarshal(fieldType)
+
 		var currFieldInfo *fieldInfo
 		if !field.Anonymous {
 			filteredTags := []string{}
@@ -94,13 +104,17 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int, parentKeys []stri
 			if len(filteredTags) == 1 && filteredTags[0] == "-" {
 				// ignore nested structs with - tag
 				continue
+			} else if isExpandableStruct && len(filteredTags) == 1 && filteredTags[0] == "." {
+				// inline nested structs with . tag
+				currFieldInfo.inline = true
+				currFieldInfo.keys = parentKeys
 			} else if len(filteredTags) > 0 && filteredTags[0] != "" {
 				currFieldInfo.keys = filteredTags
 			} else {
 				currFieldInfo.keys = []string{normalizeName(field.Name)}
 			}
 
-			if len(parentKeys) > 0 && currFieldInfo != nil {
+			if len(parentKeys) > 0 && currFieldInfo != nil && !currFieldInfo.inline {
 				// create cartesian product of keys
 				// eg: parent keys x field keys
 				keys := make([]string, 0, len(parentKeys)*len(currFieldInfo.keys))
@@ -114,24 +128,14 @@ func getFieldInfos(rType reflect.Type, parentIndexChain []int, parentKeys []stri
 		}
 
 		// handle struct
-		fieldType := field.Type
-		// if the field is a pointer, follow the pointer
-		if fieldType.Kind() == reflect.Ptr {
-			fieldType = fieldType.Elem()
-		}
-		// if the field is a struct, create a fieldInfo for each of its fields
-		if fieldType.Kind() == reflect.Struct {
-			// Structs that implement any of the text or CSV marshaling methods
-			// should result in one value and not have their fields exposed
-			if !(canMarshal(fieldType)) {
-				// if the field is an embedded struct, pass along parent keys
-				keys := parentKeys
-				if currFieldInfo != nil {
-					keys = currFieldInfo.keys
-				}
-				fieldsList = append(fieldsList, getFieldInfos(fieldType, indexChain, keys)...)
-				continue
+		if isExpandableStruct {
+			// if the field is an embedded struct, pass along parent keys
+			keys := parentKeys
+			if currFieldInfo != nil {
+				keys = currFieldInfo.keys
 			}
+			fieldsList = append(fieldsList, getFieldInfos(fieldType, indexChain, keys)...)
+			continue
 		}
 
 		// if the field is an embedded struct, ignore the csv tag

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -189,6 +189,26 @@ type NestedEmbedSample struct {
 	InnerStruct
 }
 
+type InlineBar struct {
+	A int `csv:"a"`
+	B int `csv:"b"`
+}
+
+type InlineFooSample struct {
+	Bar InlineBar `csv:"."`
+	X   int       `csv:"x"`
+}
+
+type InlineFooPtrSample struct {
+	Bar *InlineBar `csv:"."`
+	X   int        `csv:"x"`
+}
+
+type InlineOuterSample struct {
+	Foo InlineFooSample `csv:"foo"`
+	Y   int             `csv:"y"`
+}
+
 type NoTagsSample struct {
 	Fields map[string]string
 }


### PR DESCRIPTION
For example:

```
type Foo struct {
	B Bar `csv:"."`
	X int `csv:"x"`
}

type Bar struct {
	A int `csv:"a"`
	B int `csv:"b"`
}
```

produces columns a, b, x.