### PR TITLE
Apply the default tag in Unmarshaller

### DIFF
--- a/unmarshaller.go
+++ b/unmarshaller.go
@@ -108,7 +108,11 @@ func (um *Unmarshaller) unmarshalRow(row []string, unmatched map[string]string) 
 	for j, csvColumnContent := range row {
 		if j < len(um.fieldInfoMap) && um.fieldInfoMap[j] != nil {
 			fieldInfo := um.fieldInfoMap[j]
-			if err := setInnerField(&outValue, isPointer, fieldInfo.IndexChain, csvColumnContent, fieldInfo.omitEmpty); err != nil { // Set field of struct
+			value := csvColumnContent
+			if value == "" {
+				value = fieldInfo.defaultValue
+			}
+			if err := setInnerField(&outValue, isPointer, fieldInfo.IndexChain, value, fieldInfo.omitEmpty); err != nil { // Set field of struct
 				return nil, fmt.Errorf("cannot assign field at %v to %s through index chain %v: %v", j, outValue.Type(), fieldInfo.IndexChain, err)
 			}
 		} else if unmatched != nil {

--- a/unmarshaller_test.go
+++ b/unmarshaller_test.go
@@ -153,3 +153,28 @@ c,d,e
 		t.Fatalf("Unepxected result from Read(): (%#v, %#v)", obj, err)
 	}
 }
+
+func TestUnmarshallerDefaultValues(t *testing.T) {
+	type sample struct {
+		Name string `csv:"name"`
+		Qty  int    `csv:"qty,default=42"`
+		Tier string `csv:"tier,default=basic"`
+	}
+
+	const doc = "name,qty,tier\nalice,,\n"
+
+	um, err := NewUnmarshaller(csv.NewReader(strings.NewReader(doc)), sample{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := um.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// readTo and readEach already apply fieldInfo.defaultValue for an empty cell.
+	want := sample{Name: "alice", Qty: 42, Tier: "basic"}
+	if got != want {
+		t.Errorf("expected %+v, got %+v", want, got)
+	}
+}


### PR DESCRIPTION
The `default=` tag is honoured by two of the three header-mapped readers and dropped by the third.

Same struct, same document, three public entry points:

```go
type Row struct {
    Name string `csv:"name"`
    Qty  int    `csv:"qty,default=42"`
    Tier string `csv:"tier,default=basic"`
}
// "name,qty,tier\nalice,,\n"
```

```
UnmarshalString   -> {Name:alice Qty:42 Tier:basic}
Unmarshaller.Read -> {Name:alice Qty:0  Tier:}        <-- disagrees
UnmarshalToChan   -> {Name:alice Qty:42 Tier:basic}
```

### Cause

`default=` is parsed centrally into `fieldInfo.defaultValue` (`reflect.go:237`). Three reader loops
consume that same `fieldInfo`:

- `readTo` — `decode.go:222`, substitutes it for an empty cell
- `readEach` — `decode.go:326`, same
- `unmarshalRow` — `unmarshaller.go:111`, passes `csvColumnContent` straight to `setInnerField`

The third reads `fieldInfo.IndexChain` and `fieldInfo.omitEmpty` off the very same struct — it uses
every member except `defaultValue`. `ReadUnmatched` goes through `unmarshalRow` too, so it has the
same gap.

### Change

The four lines `readTo` already runs on every row, moved one loop over:

```go
value := csvColumnContent
if value == "" {
    value = fieldInfo.defaultValue
}
```

All three paths then return `{alice 42 basic}`.

This is the shape of #277 (merged) — `TypeUnmarshalCSVWithFields` existed only in `readTo` and was
copied into the sibling loop that had missed it. The gap here dates from #189, which added `default=`
and touched `decode.go`, `decode_test.go` and `reflect.go`, but not `unmarshaller.go`.

### Behaviour change worth stating

Anyone using `default=` together with `NewUnmarshaller` currently gets zero values on empty cells and
will start getting the tag default. That only affects code depending on the tag not working.

### Not included

`readToWithoutHeaders` (`decode.go:427`) and `readEachWithoutHeaders` (`decode.go:382`) also skip
defaults. Those are positional, header-free paths with a different story; the three header-mapped
readers are the coherent set, so I have left them alone.

### Verification

Test added to `unmarshaller_test.go`. Red with only `unmarshaller.go` reverted:

```
unmarshaller_test.go:178: expected {Name:alice Qty:42 Tier:basic}, got {Name:alice Qty:0 Tier:}
```

Green with the change. `go test ./...` and `go vet ./...` pass; `gofmt -l` reports only
`safe_csv.go`, which is already unformatted on master.

---

Disclosure: prepared with AI assistance; I verified the three-path comparison and the red/green run
myself.
