### PR TITLE
Parse integer fields as base 10 (fixes #182)

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1359,3 +1359,33 @@ func Test_readTo_inline_nested_struct(t *testing.T) {
 		t.Fatalf("expected \n  sample: %v\n     got: %v", expected, samples)
 	}
 }
+
+func TestUnmarshalZeroPaddedNumbers(t *testing.T) {
+	type row struct {
+		Name  string `csv:"name"`
+		Code  int    `csv:"code"`
+		Count uint   `csv:"count"`
+	}
+
+	in := "name,code,count\n" +
+		"a,08,08\n" +
+		"b,09,09\n" +
+		"c,010,010\n" +
+		"d,007,007\n"
+
+	var got []row
+	if err := UnmarshalString(in, &got); err != nil {
+		t.Fatalf("UnmarshalString failed on zero-padded numbers: %s", err)
+	}
+
+	want := []row{
+		{Name: "a", Code: 8, Count: 8},
+		{Name: "b", Code: 9, Count: 9},
+		{Name: "c", Code: 10, Count: 10},
+		{Name: "d", Code: 7, Count: 7},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("UnmarshalString returned %+v, want %+v", got, want)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -130,7 +130,8 @@ func toInt(in interface{}) (int64, error) {
 			return 0, nil
 		}
 		out := strings.SplitN(s, ".", 2)
-		return strconv.ParseInt(out[0], 0, 64)
+		// base 10, not 0: a CSV field is data, not a Go literal
+		return strconv.ParseInt(out[0], 10, 64)
 	case reflect.Bool:
 		if inValue.Bool() {
 			return 1, nil
@@ -164,7 +165,8 @@ func toUint(in interface{}) (uint64, error) {
 			}
 			return uint64(f), nil
 		}
-		return strconv.ParseUint(s, 0, 64)
+		// base 10, see toInt
+		return strconv.ParseUint(s, 10, 64)
 	case reflect.Bool:
 		if inValue.Bool() {
 			return 1, nil

--- a/types_test.go
+++ b/types_test.go
@@ -139,3 +139,58 @@ func TestToInt(t *testing.T) {
 		}
 	}
 }
+
+func TestToIntLeadingZeros(t *testing.T) {
+	testCases := []struct {
+		field  string
+		result int64
+	}{
+		{"08", 8},
+		{"09", 9},
+		{"010", 10},
+		{"007", 7},
+		{"0009", 9},
+		{"-08", -8},
+		{"-010", -10},
+		{"0", 0},
+		{"00", 0},
+		{"010.9", 10},
+	}
+
+	for _, item := range testCases {
+		out, err := toInt(item.field)
+		if err != nil {
+			t.Errorf("toInt(%q) returned an error: %s", item.field, err)
+			continue
+		}
+		if out != item.result {
+			t.Errorf("toInt(%q) = %d, want %d", item.field, out, item.result)
+		}
+	}
+}
+
+func TestToUintLeadingZeros(t *testing.T) {
+	testCases := []struct {
+		field  string
+		result uint64
+	}{
+		{"08", 8},
+		{"09", 9},
+		{"010", 10},
+		{"007", 7},
+		{"0009", 9},
+		{"0", 0},
+		{"00", 0},
+	}
+
+	for _, item := range testCases {
+		out, err := toUint(item.field)
+		if err != nil {
+			t.Errorf("toUint(%q) returned an error: %s", item.field, err)
+			continue
+		}
+		if out != item.result {
+			t.Errorf("toUint(%q) = %d, want %d", item.field, out, item.result)
+		}
+	}
+}


### PR DESCRIPTION

## Problem

Closes #182.

## Problem

`toInt` and `toUint` hand the field to `strconv` with `base` set to `0`:

```go
return strconv.ParseInt(out[0], 0, 64)   // types.go:133
return strconv.ParseUint(s, 0, 64)       // types.go:167
```

Base `0` makes `strconv` infer the base from the literal the way the Go compiler
does, so a leading zero means octal. In a CSV file that is not what the data
means, and it fails in two different ways:

| field | `int` field gets | |
|---|---|---|
| `08`   | `strconv.ParseInt: parsing "08": invalid syntax` | error |
| `09`   | `strconv.ParseInt: parsing "09": invalid syntax` | error |
| `010`  | `8` | silently wrong |
| `007`  | `7` | happens to be right |

Zero padding is ordinary in CSV exports (identifiers, codes, two-digit months
and days), and the failure mode splits on the digits used: `07` works, `08`
errors, `010` parses to a different number than the file says. The silent case
is the worse one, since nothing surfaces to the caller.

Reproduced through the public API:

```go
type row struct {
	Name  string `csv:"name"`
	Code  int    `csv:"code"`
}

gocsv.UnmarshalString("name,code\na,08\n", &rows)
// before: record on line 0; parse error on line 2, column 2:
//         strconv.ParseInt: parsing "08": invalid syntax
// after:  Code == 8
```

## Fix

Both call sites now pass base `10`, which is what the issue asks for.

## Behaviour change

Base `0` also accepted Go-style prefixed literals, so `0x1f` used to parse as
`31` and `0b101` as `5`. That is dropped by this change: those fields now
return a parse error.

This looked worth doing rather than working around, because:

- it is undocumented -- the README says nothing about prefixed literals, and
  there is no test covering them (`grep -rn "0x" *_test.go` finds nothing);
- it is the same mechanism as the bug -- you cannot keep `0x1f` == 31 through
  base inference without also keeping `010` == 8;
- the issue author raised exactly this trade-off ("I'd be surprised if there
  were `0x007` strings in a csv file that were expected to parse as hex") and
  it went unchallenged.

If you would rather keep the prefixed forms, a base-10 attempt with a base-0
fallback would do it. Say the word and I will push that instead.

## Tests

- `TestToIntLeadingZeros` / `TestToUintLeadingZeros` (`types_test.go`) cover
  `08`, `09`, `010`, `007`, `0009`, `-08`, `-010`, `0`, `00` and `010.9`.
- `TestUnmarshalZeroPaddedNumbers` (`decode_test.go`) covers the same through
  `UnmarshalString` into `int` and `uint` fields, which is how the bug is hit
  in practice.

Without the fix the unit test reports `toInt("010") = 8, want 10` plus the four
`invalid syntax` errors, and the end-to-end test fails on the first row.

Gate run on this branch:

- `go test ./...` -- ok (both packages)
- `go test -race ./...` -- ok
- `go vet ./...` -- clean
- `gofmt -l` -- only `safe_csv.go`, which is already unformatted on `master`
  and untouched here
