### PR TITLE
Allocate nested pointers independently of leaf omission

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ type Client struct { // Our example struct with a custom type (DateTime)
 Nested structs
 ---
 
+When decoding nested pointer structs, GoCSV allocates the pointers needed to
+reach each field. An `omitempty` field still omits an empty leaf pointer value;
+it does not prevent allocation of the enclosing structs.
+
 By default, the fields of nested structs are prefixed with the parent field's
 name. For example:
 

--- a/decode.go
+++ b/decode.go
@@ -502,9 +502,8 @@ func setInnerField(outInner *reflect.Value, outInnerWasPointer bool, index []int
 	if outInnerWasPointer {
 		// initialize nil pointer
 		if oi.IsNil() {
-			if err := setField(oi, "", omitEmpty); err != nil {
-				return err
-			}
+			// Allocate the traversal path independently of leaf omitempty rules.
+			oi.Set(reflect.New(oi.Type().Elem()))
 		}
 		oi = outInner.Elem()
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1389,3 +1389,82 @@ func TestUnmarshalZeroPaddedNumbers(t *testing.T) {
 		t.Errorf("UnmarshalString returned %+v, want %+v", got, want)
 	}
 }
+
+type nestedOmitChild struct {
+	Value string `csv:"value,omitempty" json:"value,omitempty"`
+}
+
+type nestedOmitRecord struct {
+	Child *nestedOmitChild `csv:"child,omitempty" json:"child,omitempty"`
+}
+
+func TestUnmarshalNestedPointerOmitEmpty(t *testing.T) {
+	input := []*nestedOmitRecord{{Child: &nestedOmitChild{Value: "present"}}}
+	encoded, err := MarshalString(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output []*nestedOmitRecord
+	if err := UnmarshalString(encoded, &output); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(input, output) {
+		t.Fatalf("round trip: got %#v, want %#v", output, input)
+	}
+}
+
+func TestNestedPointerDecodeEntryPoints(t *testing.T) {
+	input := "child.value\npresent\n"
+	for _, name := range []string{"slice", "without-headers", "channel", "channel-without-headers", "callback"} {
+		t.Run(name, func(t *testing.T) {
+			var output []*nestedOmitRecord
+			var err error
+			switch name {
+			case "slice":
+				err = UnmarshalString(input, &output)
+			case "without-headers":
+				err = UnmarshalWithoutHeaders(strings.NewReader("present\n"), &output)
+			case "channel", "channel-without-headers":
+				channel := make(chan *nestedOmitRecord, 1)
+				if name == "channel" {
+					err = UnmarshalToChan(strings.NewReader(input), channel)
+				} else {
+					err = UnmarshalToChanWithoutHeaders(strings.NewReader("present\n"), channel)
+				}
+				for record := range channel {
+					output = append(output, record)
+				}
+			case "callback":
+				err = UnmarshalToCallback(strings.NewReader(input), func(record *nestedOmitRecord) {
+					output = append(output, record)
+				})
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(output) != 1 || output[0].Child == nil || output[0].Child.Value != "present" {
+				t.Fatalf("incorrect nested output: %#v", output)
+			}
+		})
+	}
+}
+
+func TestNestedPointerLeafOmission(t *testing.T) {
+	type child struct {
+		Value string  `csv:"value,omitempty"`
+		Empty *string `csv:"empty,omitempty"`
+	}
+	type middle struct {
+		Child *child `csv:"child,omitempty"`
+	}
+	type record struct {
+		Middle *middle `csv:"middle,omitempty"`
+	}
+	var output []record
+	if err := UnmarshalString("middle.child.value,middle.child.empty\npresent,\n", &output); err != nil {
+		t.Fatal(err)
+	}
+	if output[0].Middle.Child.Value != "present" || output[0].Middle.Child.Empty != nil {
+		t.Fatalf("leaf omission changed: %#v", output[0].Middle.Child)
+	}
+}


### PR DESCRIPTION
Fixes #263.

Allocate intermediate pointers directly during nested-field traversal. Previously initialization called `setField` with an empty string, allowing `omitempty` to skip allocation even when the actual CSV field was nonempty. Traversal then panicked on the nil pointer. Leaf `omitempty` behavior is preserved.

Validation: the marshal/unmarshal round-trip regression panics before the fix. Tests cover slice, channel, callback, and headerless decoding, deeper pointer nesting, and omitted leaf pointers. `go test ./...`, `go test -race ./...`, `go vet ./...`, gofmt, and diff checks pass on Go 1.27.1/macOS. README documents the distinction between traversal allocation and leaf omission.
