### PR TITLE
Decode fixed-size arrays, not just slices

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -225,6 +225,41 @@ func Test_readTo_slice(t *testing.T) {
 	}
 }
 
+func Test_readTo_array(t *testing.T) {
+	b := bytes.NewBufferString(`Name,Array
+empty,
+short,"[1, 2]"
+full,"[1, 2, 3]"`)
+	d := newSimpleDecoderFromReader(b)
+	samples := []ArraySample{}
+	if err := readTo(d, &samples); err != nil {
+		t.Fatal(err)
+	}
+	expected := []ArraySample{
+		{Name: "empty", Array: [3]int{}},
+		{Name: "short", Array: [3]int{1, 2}},
+		{Name: "full", Array: [3]int{1, 2, 3}},
+	}
+	if !reflect.DeepEqual(expected, samples) {
+		t.Fatalf("expected %v, got %v", expected, samples)
+	}
+}
+
+func Test_array_round_trip(t *testing.T) {
+	in := []ArraySample{{Name: "full", Array: [3]int{1, 2, 3}}}
+	out, err := MarshalString(&in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back []ArraySample
+	if err := UnmarshalString(out, &back); err != nil {
+		t.Fatalf("cannot unmarshal %q produced by MarshalString: %v", out, err)
+	}
+	if !reflect.DeepEqual(in, back) {
+		t.Fatalf("expected %v, got %v", in, back)
+	}
+}
+
 func Test_readTo_slice_structs(t *testing.T) {
 	b := bytes.NewBufferString(`s[0].string,slice[0].f,slice[1].s,s[1].float,a[0].s,array[0].float,a[1].s,array[1].float,ints[0],ints[1],ints[2]
 s1,1.1,s2,2.2,s3,3.3,s4,4.4,1,2,3`)

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -19,6 +19,11 @@ type SliceSample struct {
 	Slice []int `csv:"Slice"`
 }
 
+type ArraySample struct {
+	Name  string `csv:"Name"`
+	Array [3]int `csv:"Array"`
+}
+
 type SliceStructSample struct {
 	Slice       []SliceStruct  `csv:"s,slice" csv[]:"2"`
 	Slice2      []SliceStruct  `csv:"sliceText"`

--- a/types.go
+++ b/types.go
@@ -288,7 +288,7 @@ func setField(field reflect.Value, value string, omitEmpty bool) error {
 					return err
 				}
 				field.SetFloat(f)
-			case reflect.Slice, reflect.Struct:
+			case reflect.Slice, reflect.Array, reflect.Struct:
 				if value == "" {
 					return nil
 				}


### PR DESCRIPTION
### Problem

`Marshal` writes a fixed-size array field as a single JSON column, but `Unmarshal` cannot read that column back. The library fails to round-trip its own output.

```go
type Row struct {
	Name  string `csv:"Name"`
	Array [3]int `csv:"Array"`
}

out, _ := gocsv.MarshalString(&[]Row{{Name: "full", Array: [3]int{1, 2, 3}}})
// out == "Name,Array\nfull,\"[1,2,3]\"\n"

var back []Row
err := gocsv.UnmarshalString(out, &back)
```

```
record on line 0; parse error on line 2, column 2:
No known conversion from string to , it does not implement TypeUnmarshaller
```

The sibling `[]int` field round-trips fine, which is what makes this an asymmetry rather than a missing feature.

### Why this is a bug and not a design choice

Your own `getFieldAsString` at `types.go:378` already does this. The writer's switch routes `Slice` and `Array` through the *same* branch with a literal `fallthrough`:

```go
case reflect.Slice:
	fallthrough
case reflect.Array:
	value := field.Interface()
	if field.CanAddr() {
		value = field.Addr().Interface()
	}
	b, err := json.Marshal(value)
	...
	str = string(b)
```

The reader's switch in `setField` at `types.go:291` listed only `reflect.Slice` (and `reflect.Struct`), so the `Array` column the writer is documented-by-construction to emit had no reader at all and fell into `default: return err`.

This is not a proposal to support a new kind. It is the one kind the writer already emits and the reader forgot.

### Fix

```diff
-			case reflect.Slice, reflect.Struct:
+			case reflect.Slice, reflect.Array, reflect.Struct:
 				if value == "" {
 					return nil
 				}
```

Arrays of structs are unaffected: `reflect.go:146` expands a slice-or-array whose element kind is `Struct` into per-index columns before `setField` is ever reached, so only plain leaf arrays take this path.

Short JSON input leaves the remaining elements at their zero value, which is `encoding/json`'s documented behaviour for arrays and matches what the empty-string guard directly above already does.

### Tests

Two tests in `decode_test.go`, plus an `ArraySample` type in `sample_structs_test.go`:

- `Test_readTo_array` - decodes `""`, `"[1, 2]"` and `"[1, 2, 3]"` into a `[3]int` column.
- `Test_array_round_trip` - marshals a `[3]int` row and unmarshals the exact string back.

Both fail on `master` and pass with the change.

Mutation-checked in both directions:

| mutant | result |
| --- | --- |
| revert `reflect.Array` (i.e. `master`) | both new tests fail |
| drop the `if value == "" { return nil }` guard | only `Test_readTo_array` fails, on the empty cell - disjoint from the above |
| revert the reader **and** delete the writer's `Array` branch instead | both fail - `Test_array_round_trip` reports the column came back empty |

The last one is the informative one: it fixes the *other* side of the writer/reader asymmetry, and the test rejects it, so the test pins which side is wrong rather than merely detecting that the two disagree.

### Verification

Gates taken verbatim from `.github/workflows/go.yml`, the repository's only workflow:

| gate | result |
| --- | --- |
| `go build -v ./...` | pass |
| `go test -v ./...` | pass, 74 `--- PASS` |
| `go vet ./...` | pass |
| `gofmt -l types.go decode_test.go sample_structs_test.go` | empty |

---

Disclosure: this patch was prepared with AI assistance. I have reviewed and tested it myself, and I am responsible for its correctness.
